### PR TITLE
fix ruby incompatible issue

### DIFF
--- a/lib/Helper.rb
+++ b/lib/Helper.rb
@@ -40,7 +40,7 @@ class Helper
         begin
             dir = dirs.shift
             currentDir = "#{currentDir}/#{dir}"
-            Dir.mkdir(currentDir) unless File.exists?(currentDir)
+            Dir.mkdir(currentDir) unless File.exist?(currentDir)
         end while dirs.length > 0
     end
 

--- a/lib/ZMediumFetcher.rb
+++ b/lib/ZMediumFetcher.rb
@@ -362,7 +362,7 @@ class ZMediumFetcher
         index = 1
         postURLS.each do |postURL|
           begin
-            # todo: unless File.exists? Post.getPostPathFromPostURLString(postURL) +".md"
+            # todo: unless File.exist? Post.getPostPathFromPostURLString(postURL) +".md"
             downloadPost(postURL["url"], downloadPathPolicy, postURL["pin"]) 
           rescue => e
             puts e


### PR DESCRIPTION
As per issue #18, the incompatible problem was due to "exists?" is no longer supported. I just changed them into "exist?"
This is tested and it works well with ruby 3.4.2 (latest).