### PR TITLE
fix: restore tweet embedding via Twitter syndication API

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,244 +2,256 @@
 
 ![ZMediumToMarkdown](https://user-images.githubusercontent.com/33706588/184416147-c2ec74d4-7107-484e-8ad2-302340cf6c1f.png)
 
-ZMediumToMarkdown is a powerful tool that allows you to effortlessly download and convert your Medium posts to Markdown format. 
+Download Medium posts and convert them to Markdown — for static blog import, automatic backups, or one-off scraping.
 
-This project can help you create an auto-sync or auto-backup service from Medium, such as automatically syncing Medium posts to Jekyll or other static markdown blog engines, or backing up Medium posts to Github pages.
+[![Gem](https://badge.fury.io/rb/ZMediumToMarkdown.svg)](https://rubygems.org/gems/ZMediumToMarkdown)
+&nbsp;[中文介紹](https://medium.com/zrealm-ios-dev/converting-medium-posts-to-markdown-ddd88a84e177)
 
-[![ZMediumToMarkdown](https://badge.fury.io/rb/ZMediumToMarkdown.svg)](https://rubygems.org/gems/ZMediumToMarkdown)
+```bash
+gem install ZMediumToMarkdown
+ZMediumToMarkdown -p "https://medium.com/<USER>/<POST>" -s "$MEDIUM_COOKIE_SID" -d "$MEDIUM_COOKIE_UID"
+```
 
-- [中文](https://medium.com/zrealm-ios-dev/converting-medium-posts-to-markdown-ddd88a84e177)
-
-
-## Features
-- [x] Supports downloading posts and converting them to markdown format
-- [x] Supports downloading all posts and converting them to markdown format from any user without requiring login access
-- [x] Supports downloading paid content
-- [x] Supports downloading all of a post's images to the local drive and converting them to local paths
-- [x] Supports parsing Twitter tweet content to blockquotes
-- [x] Supports a command line interface
-- [x] Converts Gist source code to markdown code blocks
-- [x] Converts YouTube links embedded in a post to preview images
-- [x] Adjusts a post's last modification date from Medium to the locally downloaded markdown file
-- [x] Auto-skips posts that have already been downloaded and whose last modification date from Medium hasn't changed (convenient for auto-sync or auto-backup services, to save server bandwidth and execution time)
-- [x] Supports using Github Action as an auto-sync/backup service
-- [x] Highly optimized markdown format for Medium
-- [x] Native Markdown-style Render Engine
-(Feel free to contribute if you have any optimization ideas! MarkupStyleRender.rb)
-- [x] **Supports paywall posts.** (Requires providing valid Medium Member cookies)
-- [x] Jekyll and social share (og: tag) friendly
-- [x] 100% Ruby @ RubyGem
-
-# Buy me a beer ❤️❤️❤️
-
-[![Buy Me A Beer](https://github.com/user-attachments/assets/63f01edf-2aa5-4d91-8f8a-861e5b6b4feb)](https://www.paypal.com/ncp/payment/CMALMPT8UUTY2)
-
-[**If this project has helped you, feel free to sponsor me a cup of coffee, thank you.**](https://www.paypal.com/ncp/payment/CMALMPT8UUTY2)
-
-## Result
-- [Original post on Medium](https://medium.com/zrealm-ios-dev/avplayer-%E5%AF%A6%E8%B8%90%E6%9C%AC%E5%9C%B0-cache-%E5%8A%9F%E8%83%BD%E5%A4%A7%E5%85%A8-6ce488898003)
-- [Downloaded & Converted Output Result](example/2021-01-31-avplayer-實踐本地-cache-功能大全-6ce488898003.md)
-![Harry's Idea Draw](https://user-images.githubusercontent.com/33706588/171560402-40b23bec-a836-4468-9f07-68350ce82d4a.jpg)
-
-and I use this tool to convert from Meidum to [jekyllrb](https://zhgchg.li/)
-
-## medium-to-jekyll-starter
-
-I have just created a brand new GitHub repository template that allows you to move your Medium blog to your own Jekyll blog with just one click. Check it out: [medium-to-jekyll-starter](https://github.com/ZhgChgLi/medium-to-jekyll-starter.github.io).
-
-### I'M NOT GEEK, PLEASE SHOW ME HOW TO USE WITHOUT CODING
-
-- Please follow this post, step by step to creat your auto backup service without any coding:
-
-[How to use Github Action as your free & no code Medium Posts backup service](https://github.com/ZhgChgLi/ZMediumToMarkdown/wiki/How-to-use-Github-Action-as-your-free-&-no-code-Medium-Posts-backup-service)
+> ⚠ **Strongly recommended: provide your Medium login cookies.**
+> Medium fronts its API with Cloudflare and frequently blocks unauthenticated traffic — especially from cloud runners (GitHub Actions, Docker hosts, datacenter IPs). Without cookies you may get partial output, an HTTP 403 “Just a moment...” block, or paywalled content trimmed to its preview. See [Cookie setup](#cookie-setup) below.
 
 ---
 
-## Setup
+## Features
+
+- Download a single post, or every post by a Medium username
+- Full Medium markup support: headings, blockquotes, lists, inline code, code fences with language, images (downloaded locally), embedded gists (rewritten to fenced code), tweets (rendered as blockquotes via the public syndication endpoint), YouTube cards, generic OG-image embeds
+- Paywalled posts supported when authenticated cookies are provided
+- Jekyll-friendly mode (front matter, `_posts/` layout, asset paths, `{:target="_blank"}` link markers)
+- Skip-already-downloaded based on `last_modified_at` so it’s safe to run on a cron
+- Multilingual: CJK / Arabic / Hebrew / Cyrillic / emoji all round-trip cleanly
+- Ships as a gem and as a Docker image; usable from a GitHub Actions workflow
+
+---
+
+## Cookie setup
+
+Medium’s GraphQL endpoint is behind Cloudflare’s bot management. Without a logged-in cookie, two things happen:
+
+1. **Cloudflare may reject the request** with an HTTP 403 “Just a moment…” challenge page. Cloud-based runners (GitHub Actions, datacenter IPs, headless browsers) are particularly prone to this.
+2. **Paywalled posts come back with `isLockedPreviewOnly: true`** and only the public preview text is returned by Medium — no amount of retries fixes that without authentication.
+
+This tool detects both situations and prints actionable guidance, but it’s much easier to just provide cookies up front.
+
+### How to get your `sid` and `uid`
+
+1. Open <https://medium.com> in a browser, logged in to your account.
+2. Open DevTools → **Application** (Chrome) or **Storage** (Firefox/Safari) → **Cookies** → `https://medium.com`.
+3. Copy the values of the `sid` and `uid` cookies.
+
+> Cookies expire roughly every two weeks — if downloads stop working, refresh them.
+
+### Pass cookies to the CLI
+
+Either as flags:
+
+```bash
+ZMediumToMarkdown -p "https://medium.com/..." \
+                  -s "<your sid>" \
+                  -d "<your uid>"
+```
+
+…or via environment variables (preferred — keeps secrets out of shell history):
+
+```bash
+export MEDIUM_COOKIE_SID="<your sid>"
+export MEDIUM_COOKIE_UID="<your uid>"
+ZMediumToMarkdown -p "https://medium.com/..."
+```
+
+CLI flags take precedence over environment variables.
+
+### Still blocked by Cloudflare?
+
+If even authenticated requests get challenged (typical when running from a datacenter IP), the most reliable workaround is to proxy traffic through a Cloudflare Worker so the request originates from inside Cloudflare’s own network. Walkthrough and complete GraphQL operation reference here:
+
+> [Medium API 爬取資料與突破 Cloudflare 防護｜完整 GraphQL 操作教學](https://zhgchg.li/posts/zrealm-dev/medium-api-%E7%88%AC%E5%8F%96%E8%B3%87%E6%96%99%E8%88%87%E7%AA%81%E7%A0%B4-cloudflare-%E9%98%B2%E8%AD%B7-%E5%AE%8C%E6%95%B4-graphql-%E6%93%8D%E4%BD%9C%E6%95%99%E5%AD%B8-88f0fb935120/)
+
+You can point the tool at your proxy via env vars:
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `MEDIUM_HOST` | `https://medium.com/_/graphql` | GraphQL endpoint |
+| `MIRO_MEDIUM_HOST` | `https://miro.medium.com` | Image CDN |
+| `TWITTER_SYNDICATION_HOST` | `https://cdn.syndication.twitter.com` | Tweet embed source |
+
+---
+
+## Installation
+
+### Gem (recommended)
+
+```bash
+gem install ZMediumToMarkdown
+```
+
+If you’re on macOS, prefer a managed Ruby (`rbenv` / `rvm` / `asdf`) over the system Ruby — `gem install` against `/usr/bin/ruby` requires `sudo` and pollutes the OS.
+
+### From source
+
+```bash
+git clone https://github.com/ZhgChgLi/ZMediumToMarkdown
+cd ZMediumToMarkdown
+bundle install
+bundle exec ruby bin/ZMediumToMarkdown -p "https://medium.com/..."
+```
 
 ### Docker
-1. make sure has [Docker](https://www.docker.com/products/docker-desktop/) on your system.
-2. git clone this repo `git clone https://github.com/ZhgChgLi/ZMediumToMarkdown`
-3. `cd /ZMediumToMarkdown`
-4. build docker image `docker build -t zmediumtomarkdown:latest --build-arg CRON_SETTING="0 8 * * *" --build-arg ZMEDIUMTOMARKDOWN_COMMAND="-u [YOUR_MEDIUM_USERNAME]" .`
-   - ZMEDIUMTOMARKDOWN_COMMAND = ZMediumToMarkdown Command (Refer to the configuration block down below.)
-6. Refer to the configuration block down below and finish the configuration.
-7. run docker `docker run -v ./:/usr/src/app zmediumtomarkdown`
-8. have fun!
 
-
-### Using Gem
-#### If you are familiar with ruby:
-1. make sure you have Ruby in your environment (I use `3.4.2`)
-2. make sure you have Bundle in your environment (I use `2.3.13`)
-3. type `gem install ZMediumToMarkdown` in terminal
-
-#### If you are **NOT** familiar with ruby:
-1. MacOS comes with a System Ruby pre-installed, but we are **NOT** Recommend to use that, using rvm/rbenv's Ruby instead.
-2. install [rbenv](https://github.com/rbenv/rbenv) or [rvm](https://rvm.io/) to manage Ruby environment
-3. install Ruby through rbenv/rym (you can install ruby version `2.6.X`)
-4. change the systme ruby to rbenv/rvm's Ruby
-5. type `which ruby` in terminal to make sure current Ruby is **NOT** `/usr/bin/ruby`
-6. type `gem install ZMediumToMarkdown` in terminal
-
-#### Usage
-Command: `ZMediumToMarkdown`
-
-**Downloading all posts from any user**
-```
-ZMediumToMarkdown -u [USEERNAME]
+```bash
+docker build -t zmediumtomarkdown:latest \
+  --build-arg CRON_SETTING="0 8 * * *" \
+  --build-arg ZMEDIUMTOMARKDOWN_COMMAND="-u <username> -s $MEDIUM_COOKIE_SID -d $MEDIUM_COOKIE_UID" \
+  .
+docker run -v "$(pwd)":/usr/src/app zmediumtomarkdown
 ```
 
-**Downloading single post**
-```
-ZMediumToMarkdown -p [MEDIUM POST URL]
-```
+The image runs `cron` so the configured command repeats on the schedule you pass in. Output is written to the mounted volume.
 
-**Update to latest version**
-```
-ZMediumToMarkdown -n
-```
+---
 
-**Remove all downloaded posts data**
-```
-ZMediumToMarkdown -c
-```
-
-**Print current ZMediumToMarkdown Version & Output Path**
-```
-ZMediumToMarkdown -v
-```
-
-**Provide valid Medium Member cookies to access paywall posts**
-ZMediumToMarkdown requires uid and sid cookies to access paywalled posts on Medium.
-
-If you don’t provide valid Medium Member cookies, you will receive this warning message while downloading a Medium post if the post is behind a paywall:
-> This post is behind Medium's paywall. You must provide valid Medium Member login cookies to download the full post.
+## Usage
 
 ```
-ZMediumToMarkdown --cookie_uid uid --cookie_sid sid
+ZMediumToMarkdown [options]
+
+  -s, --cookie_sid SID             Medium logged-in cookie sid (or $MEDIUM_COOKIE_SID)
+  -d, --cookie_uid UID             Medium logged-in cookie uid (or $MEDIUM_COOKIE_UID)
+  -u, --username USERNAME          Download every post by a Medium username
+  -p, --postURL POST_URL           Download a single post URL
+      --jekyll                     Emit Jekyll-friendly output (combine with -u or -p)
+  -n, --new                        Update to the latest version (gem install only)
+  -c, --clean                      Remove every downloaded post under cwd
+  -v, --version                    Print the current version
+  -h, --help                       Show this message
 ```
 
-You can obtain `cookie_uid` and `cookie_sid` from Medium by following these steps:
-1. Log in to a valid Medium Member account.
-2. Right-click anywhere on the Medium webpage.
-3. Select "Inspect" to open the Developer Tools.
-4. Navigate to the "Application" tab and locate the `sid` and `uid` values under "Cookies."
+### Examples
 
-![ZhgChgLi-2024-08-11_22-30-03](https://github.com/user-attachments/assets/35229d1d-501a-4ecf-8f3e-592a02416bb1)
+```bash
+# Single post into ./Output/zmediumtomarkdown/
+ZMediumToMarkdown -p "https://medium.com/<user>/<slug>-<id>"
 
+# Every post by a user, Jekyll-friendly into ./_posts/zmediumtomarkdown/ + ./assets/
+ZMediumToMarkdown -u zhgchgli --jekyll
 
-
-#### For Jeklly Dir Friendly
-
-**Downloading all posts from user with Jekyll friendly**
-```
-ZMediumToMarkdown -j [USEERNAME]
+# With cookies (paywall + Cloudflare workaround)
+ZMediumToMarkdown -u zhgchgli -s "$MEDIUM_COOKIE_SID" -d "$MEDIUM_COOKIE_UID"
 ```
 
-**Downloading single post with Jekyll friendly**
-```
-ZMediumToMarkdown -k [MEDIUM POST URL]
-```
+> **Deprecated flags.** `-j USERNAME` and `-k POST_URL` still work for backwards compatibility but emit a warning. Use `--jekyll -u …` / `--jekyll -p …` instead.
 
-#### Manually 
-1. MacOS comes with a System Ruby pre-installed, but we are **NOT** Recommend to use that, using rvm/rbenv's Ruby instead.
-2. install [rbenv](https://github.com/rbenv/rbenv) or [rvm](https://rvm.io/) to manage Ruby environment
-3. install Ruby through rbenv/rym (you can install ruby version `2.6.X`)
-4. change the systme ruby to rbenv/rvm's Ruby
-5. type `which ruby` in terminal to make sure current Ruby is **NOT** `/usr/bin/ruby`
-6. type `gem install bundler` install RubyGem dependency manager (you can install Bundle version `2.3.x`)
-7. git clone or download this project
-8. type `cd ./ZMediumToMarkdown` go into project
-9. type `bundle install` in terminal to install project dependencies
-10. use `bundle exec ruby [USAGE Command]` in the furture (USAGE Command write down below)
+### Output layout
 
-#### Usage
-Execute File: `bin/ZMediumToMarkdown`
+| Mode | Markdown destination | Image destination |
+|---|---|---|
+| Plain (`-p` / `-u`) | `./Output/zmediumtomarkdown/<date>-<slug>.md` | `./Output/zmediumtomarkdown/assets/<post_id>/` |
+| Jekyll (`--jekyll`) | `./_posts/zmediumtomarkdown/<date>-<post_id>.md` | `./assets/<post_id>/` |
 
-**Downloading all posts from any user**
-```
-bundle exec ruby bin/ZMediumToMarkdown -u [USEERNAME]
-```
+When run with `-u`, plain mode additionally nests under `./Output/users/<username>/`.
 
-**Downloading single post**
-```
-bundle exec ruby bin/ZMediumToMarkdown -p [MEDIUM POST URL]
-```
+Reruns are cheap — posts whose `last_modified_at` matches the existing front matter are skipped.
 
-**Update to latest version**
-```
-bundle exec ruby bin/ZMediumToMarkdown -n
-```
+---
 
-**Remove all downloaded posts data**
-```
-bundle exec ruby bin/ZMediumToMarkdown -c
-```
+## Quick-start templates
 
-**Print current ZMediumToMarkdown Version & Output Path**
-```
-bundle exec ruby bin/ZMediumToMarkdown -v
-```
+- **One-click Jekyll backup**: <https://github.com/ZhgChgLi/medium-to-jekyll-starter.github.io>
+- **GitHub Actions backup, no code**: [How-to walkthrough](https://github.com/ZhgChgLi/ZMediumToMarkdown/wiki/How-to-use-Github-Action-as-your-free-&-no-code-Medium-Posts-backup-service)
+- **Working Action repo example**: <https://github.com/ZhgChgLi/ZMediumToMarkdown-github-action>
 
-## Output
-### Where can I find the results of the downloaded post?
-The default path of the downloaded post will be in the `./Output` directory.
-- Downloading all posts from user：`./Ouput/users/[USERNAME]/posts/[POST_PATH_NAME]`
-- Downloading single post：`./Ouput/posts/[POST_PATH_NAME]`
-- Post's images：`[POST_PATH_NAME]/images/[POST_ID]/[IMAGE_PATH_NAME]`
+### Minimal GitHub Action
 
-## Disclaimer
-
-All content downloaded using ZMediumToMarkdown, including but not limited to articles, images, and videos, are subject to copyright laws and belong to their respective owners. ZMediumToMarkdown does not claim ownership of any content downloaded using this tool.
-
-Downloading and using copyrighted content without the owner's permission may be illegal and may result in legal action. ZMediumToMarkdown does not condone or support copyright infringement and will not be held responsible for any misuse of this tool.
-
-Users of ZMediumToMarkdown are solely responsible for ensuring that they have the necessary permissions and rights to download and use any content obtained using this tool. ZMediumToMarkdown is not responsible for any legal issues that may arise from the misuse of this tool.
-
-By using ZMediumToMarkdown, users acknowledge and agree to comply with all applicable copyright laws and regulations.
-
-## Using Github Action as your [free](https://docs.github.com/en/actions/learn-github-actions/usage-limits-billing-and-administration) auto sync/backup service
-```yml
+```yaml
 name: ZMediumToMarkdown
 on:
   workflow_dispatch:
   schedule:
-    - cron: "10 1 15 * *" # At 01:10 on day-of-month 15.
+    - cron: "10 1 15 * *" # 01:10 on day-of-month 15
 jobs:
-  ZMediumToMarkdown:
+  backup:
     runs-on: ubuntu-latest
     steps:
-    - name: ZMediumToMarkdown Automatic Bot
-      uses: ZhgChgLi/ZMediumToMarkdown@main
-      with:
-        command: '[USAGE Command]' # e.g. -u zhgchgli
+      - uses: ZhgChgLi/ZMediumToMarkdown@main
+        with:
+          command: "-u zhgchgli -s ${{ secrets.MEDIUM_COOKIE_SID }} -d ${{ secrets.MEDIUM_COOKIE_UID }}"
 ```
-[exmaple repo](https://github.com/ZhgChgLi/ZMediumToMarkdown-github-action)
 
-## Things to know
-- If you would like to remove the ZMediumToMarkdown watermark located at the bottom of the page, you may do so. I don't mind.
-- Since ZMediumToMarkdown is not an official tool and Medium does not provide a public API for it, I cannot guarantee that the parser target will not change in the future. However, I have tried to test it for as many cases as possible. If you encounter any rendering errors, please feel free to create an issue and I will fix them as soon as possible.
+Store `MEDIUM_COOKIE_SID` / `MEDIUM_COOKIE_UID` as repository secrets — never commit them.
 
-## About
-- [ZhgChg.Li](https://zhgchg.li/)
-- [ZhgChgLi's Medium](https://blog.zhgchg.li/)
+---
+
+## Example output
+
+- [Original post on Medium](https://medium.com/zrealm-ios-dev/avplayer-%E5%AF%A6%E8%B8%90%E6%9C%AC%E5%9C%B0-cache-%E5%8A%9F%E8%83%BD%E5%A4%A7%E5%85%A8-6ce488898003)
+- [Converted Markdown output](example/2021-01-31-avplayer-實踐本地-cache-功能大全-6ce488898003.md)
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `Blocked by Medium's Cloudflare layer (HTTP 403)` | Unauthenticated request, or your IP is on Cloudflare’s bot list | Provide cookies (`-s` / `-d` or env vars). If the IP itself is the problem, proxy via a Cloudflare Worker — see [the article](#still-blocked-by-cloudflare). |
+| `This post is behind Medium's paywall…` even though I set cookies | Cookies don’t belong to a Medium **Member** account, or they’ve expired (~2 weeks) | Refresh `sid` / `uid` from a logged-in browser; verify the account has access to the post. |
+| `Error: Too Many Requests, blocked by Medium` | Hit Medium’s rate limit | Slow the schedule down or split the run; the tool already retries up to 10 times. |
+| Markdown looks fine but CJK / emoji is mojibaked | Older release — encoding regression | Upgrade to ≥ 2.6.7 (this release force-encodes all responses to UTF-8). |
+| `An iframe came back blank` | Generic embed (non-Twitter, non-gist, non-YouTube, non-widgetic) without an OG image | Expected — the source has no image to embed. The tool emits an empty line so paragraph spacing is preserved. |
+
+---
+
+## Development
+
+```bash
+bundle install
+bundle exec rake test         # run the minitest suite
+```
+
+The suite includes a 174-paragraph end-to-end fixture under `test/fixtures/`. To regenerate the golden Markdown file after intentional output changes:
+
+```bash
+UPDATE_FIXTURES=1 bundle exec rake test
+```
+
+CI runs the same `rake test` against Ruby 3.2 / 3.3 / 3.4.
+
+---
+
+## Disclaimer
+
+All content downloaded using ZMediumToMarkdown — articles, images, video — is subject to copyright and belongs to its respective owner. This tool does not claim ownership of any downloaded content.
+
+Downloading and using copyrighted content without the owner's permission may be illegal. ZMediumToMarkdown does not condone copyright infringement and will not be held responsible for misuse of this tool. Users are solely responsible for ensuring they have the necessary permissions and rights for any content they download.
+
+By using ZMediumToMarkdown you acknowledge and agree to comply with all applicable copyright laws and regulations.
+
+---
 
 ## Other works
-### Swift Libraries
-- [ZMarkupParser](https://github.com/ZhgChgLi/ZMarkupParser) is a pure-Swift library that helps you to convert HTML strings to NSAttributedString with customized style and tags.
-- [ZPlayerCacher](https://github.com/ZhgChgLi/ZPlayerCacher) is a lightweight implementation of the AVAssetResourceLoaderDelegate protocol that enables AVPlayerItem to support caching streaming files.
 
-### Integration Tools
-- [XCFolder](https://github.com/ZhgChgLi/XCFolder) is a powerful command-line tool that converts Xcode virtual groups into actual directories, reorganizing your project structure to align with Xcode groups and enabling seamless integration with modern Xcode project generation tools like Tuist and XcodeGen.
-- [ZReviewTender](https://github.com/ZhgChgLi/ZReviewTender) is a tool for fetching app reviews from the App Store and Google Play Console and integrating them into your workflow.
-- [ZMediumToMarkdown](https://github.com/ZhgChgLi/ZMediumToMarkdown) is a powerful tool that allows you to effortlessly download and convert your Medium posts to Markdown format.
-- [linkyee](https://github.com/ZhgChgLi/linkyee) is a fully customized, open-source LinkTree alternative deployed directly on GitHub Pages.
+**Swift libraries**
+- [ZMarkupParser](https://github.com/ZhgChgLi/ZMarkupParser) — pure-Swift HTML → `NSAttributedString` with customizable style/tag mapping.
+- [ZPlayerCacher](https://github.com/ZhgChgLi/ZPlayerCacher) — lightweight `AVAssetResourceLoaderDelegate` cache for `AVPlayerItem` streaming.
 
-# Donate
+**Integration tools**
+- [XCFolder](https://github.com/ZhgChgLi/XCFolder) — convert Xcode virtual groups to real directories (Tuist / XcodeGen friendly).
+- [ZReviewTender](https://github.com/ZhgChgLi/ZReviewTender) — fetch App Store / Google Play reviews into your workflow.
+- [linkyee](https://github.com/ZhgChgLi/linkyee) — open-source LinkTree alternative on GitHub Pages.
+
+---
+
+## About
+
+- <https://zhgchg.li/>
+- <https://blog.zhgchg.li/>
+
+## Donate
 
 [![Buy Me A Beer](https://github.com/user-attachments/assets/63f01edf-2aa5-4d91-8f8a-861e5b6b4feb)](https://www.paypal.com/ncp/payment/CMALMPT8UUTY2)
 
-If you find this library helpful, please consider starring the repo or recommending it to your friends.
-
-Feel free to open an issue or submit a fix/contribution via pull request. :)
+If this project helped you, please star the repo or [buy me a beer](https://www.paypal.com/ncp/payment/CMALMPT8UUTY2). PRs and issue reports welcome.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ ZMediumToMarkdown -p "https://medium.com/<USER>/<POST>" -s "$MEDIUM_COOKIE_SID" 
 ## Features
 
 - Download a single post, or every post by a Medium username
-- Full Medium markup support: headings, blockquotes, lists, inline code, code fences with language, images (downloaded locally), embedded gists (rewritten to fenced code), tweets (rendered as blockquotes via the public syndication endpoint), YouTube cards, generic OG-image embeds
+- Full Medium markup support: headings, blockquotes, lists, inline code, code fences with language, images (downloaded locally), embedded gists (rewritten to fenced code), tweets (rendered as blockquotes via the public syndication endpoint — supports both `twitter.com` and `x.com`), YouTube / Vimeo / SoundCloud / Spotify embeds (Jekyll mode emits player iframes; plain mode renders local-thumbnail cards), generic OG-image embeds for everything else
 - Paywalled posts supported when authenticated cookies are provided
 - Jekyll-friendly mode (front matter, `_posts/` layout, asset paths, `{:target="_blank"}` link markers)
 - Skip-already-downloaded based on `last_modified_at` so it’s safe to run on a cron

--- a/bin/ZMediumToMarkdown
+++ b/bin/ZMediumToMarkdown
@@ -1,123 +1,25 @@
 #!/usr/bin/env ruby
 # -*- coding: utf-8 -*-
 
-$lib = File.expand_path('../lib', File.dirname(__FILE__))
-$LOAD_PATH.unshift($lib)
+$LOAD_PATH.unshift(File.expand_path('../lib', __dir__))
 
-require "ZMediumFetcher"
-require "Helper"
-require "optparse"
+require 'CLI'
 
-$cookies = {}
+$cookies ||= {}
 
-class Main
-    def initialize
-        fetcher = ZMediumFetcher.new
-        ARGV << '-h' if ARGV.empty?
-
-        options = {}
-        filePath = ENV['PWD'] || ::Dir.pwd
-        
-        OptionParser.new do |opts|
-            opts.banner = "Usage: ZMediumFetcher [options]"
-            
-            opts.on('-s', '--cookie_sid COOKIESID', 'Your logged-in Medium cookie sid value') do |cookie_sid|
-                $cookies['sid'] = cookie_sid
-            end
-
-            opts.on('-d', '--cookie_uid COOKIEUID', 'Your logged-in Medium cookie uid value') do |cookie_uid|
-                $cookies['uid'] = cookie_uid
-            end
-
-            opts.on('-u', '--username USERNAME', 'Downloading all posts from user') do |username|
-                options[:u] = username
-            end
-        
-            opts.on('-p', '--postURL POST_URL', 'Downloading single post') do |postURL|
-                options[:p] = postURL
-            end
-
-            opts.on('-j', '--jekyllUsername USERNAME', 'Downloading all posts from user with Jekyll friendly') do |username|
-                options[:j] = username
-            end
-        
-            opts.on('-k', '--jekyllPostURL POST_URL', 'Downloading single post with Jekyll friendly') do |postURL|
-                options[:k] = postURL
-            end
-
-            opts.on('-n', '--new', 'Update to latest version') do
-                options[:n] = true
-            end
-
-            opts.on('-c', '--clean', 'Remove all downloaded posts data') do
-                options[:c] = true
-            end
-
-            opts.on('-v', '--version', 'Print current ZMediumToMarkdown Version & Output Path') do
-                options[:v] = true
-            end
-        end.parse!
-
-        #
-        if !options[:v].nil? && options[:v] == true
-            puts "Version:#{Helper.getLocalVersion().to_s}"
-
-            Helper.printNewVersionMessageIfExists()
-        elsif !options[:c].nil? && options[:c] == true
-            outputFilePath = PathPolicy.new(filePath, "")
-            FileUtils.rm_rf(Dir[outputFilePath.getAbsolutePath(nil)])
-            puts "All downloaded posts data has been removed."
-
-            Helper.printNewVersionMessageIfExists()
-        elsif !options[:n].nil? && options[:n] == true
-            if Helper.getRemoteVersionFromGithub() > Helper.getLocalVersion()
-                Helper.downloadLatestVersion()
-            else
-                puts "You're using the latest version :)"
-            end
-        elsif !options[:k].nil?
-            postURL = options[:k]
-
-            outputFilePath = PathPolicy.new(filePath, "")
-            fetcher.isForJekyll = true
-            fetcher.downloadPost(postURL, outputFilePath, nil)
-
-            Helper.printNewVersionMessageIfExists()
-        elsif !options[:j].nil?
-            username = options[:j]
-
-            outputFilePath = PathPolicy.new(filePath, "")
-            fetcher.isForJekyll = true
-            fetcher.downloadPostsByUsername(username, outputFilePath)
-
-            Helper.printNewVersionMessageIfExists()
-        elsif !options[:p].nil?
-            postURL = options[:p]
-
-            outputFilePath = PathPolicy.new("#{filePath}/Output", "Output")
-            fetcher.downloadPost(postURL, outputFilePath, nil)
-
-            Helper.printNewVersionMessageIfExists()
-        elsif !options[:u].nil?
-            username = options[:u]
-
-            outputFilePath = PathPolicy.new("#{filePath}/Output", "Output")
-            fetcher.downloadPostsByUsername(username, outputFilePath)
-
-            Helper.printNewVersionMessageIfExists()
-        end
-
-    end
-end
-
-begin 
+begin
     puts "#https://github.com/ZhgChgLi/ZMediumToMarkdown"
     puts "You have read and agree with the Disclaimer."
-    Main.new()
+
+    CLI.main(ARGV)
+
     puts "Execute Successfully!!!"
     puts "#https://github.com/ZhgChgLi/ZMediumToMarkdown"
     puts "#Thanks for using this tool."
     puts "#If this is helpful, please help to star the repo or recommend it to your friends."
+rescue Request::CloudflareBlockedError => e
+    warn "\n#{e.message}\n"
+    exit 1
 rescue => e
     puts "#Error: #{e.class} #{e.message}\n"
     puts e.backtrace

--- a/lib/CLI.rb
+++ b/lib/CLI.rb
@@ -1,0 +1,189 @@
+require 'optparse'
+require 'fileutils'
+
+require 'ZMediumFetcher'
+require 'Helper'
+require 'PathPolicy'
+require 'Request'
+
+# All CLI-side concerns for the `ZMediumToMarkdown` executable. Pulled out
+# of bin/ so it can be exercised by unit tests without spawning processes.
+module CLI
+    COOKIE_SETUP_URL = 'https://zhgchg.li/posts/zrealm-dev/medium-api-%E7%88%AC%E5%8F%96%E8%B3%87%E6%96%99%E8%88%87%E7%AA%81%E7%A0%B4-cloudflare-%E9%98%B2%E8%AD%B7-%E5%AE%8C%E6%95%B4-graphql-%E6%93%8D%E4%BD%9C%E6%95%99%E5%AD%B8-88f0fb935120/'.freeze
+
+    COOKIE_WARNING_BANNER = <<~BANNER.strip.freeze
+      ──────────────────────────────────────────────────────────────────────
+      ⚠  No Medium login cookie detected.
+
+      Medium's Cloudflare layer often blocks unauthenticated requests
+      (especially from cloud runners / CI / Docker), and paywalled posts
+      can't be fetched in full. Strongly recommended to provide cookies:
+
+        ZMediumToMarkdown -p URL -s YOUR_SID -d YOUR_UID
+        # or via env (less likely to leak into shell history):
+        MEDIUM_COOKIE_SID=... MEDIUM_COOKIE_UID=... ZMediumToMarkdown -p URL
+
+      How to get sid / uid:
+        1. Open https://medium.com in a browser, logged in.
+        2. DevTools -> Application/Storage -> Cookies -> medium.com.
+        3. Copy the values of the `sid` and `uid` cookies.
+
+      Background and a Cloudflare Worker proxy workaround:
+        #{COOKIE_SETUP_URL}
+      ──────────────────────────────────────────────────────────────────────
+    BANNER
+
+    module_function
+
+    def main(argv, output: $stdout, errput: $stderr, cwd: ENV['PWD'] || ::Dir.pwd)
+        argv = argv.dup
+        argv << '-h' if argv.empty?
+
+        options = parseArgs(argv, errput: errput)
+        loadCookiesFromEnv!
+        warnIfNoCookies(options, errput: errput)
+        run(options, cwd, output: output)
+    end
+
+    def parseArgs(argv, errput: $stderr)
+        options = {}
+        parser = OptionParser.new do |opts|
+            opts.banner = "Usage: ZMediumToMarkdown [options]"
+
+            opts.on('-s', '--cookie_sid SID', 'Medium logged-in cookie sid value (or set $MEDIUM_COOKIE_SID)') do |v|
+                $cookies['sid'] = v
+            end
+
+            opts.on('-d', '--cookie_uid UID', 'Medium logged-in cookie uid value (or set $MEDIUM_COOKIE_UID)') do |v|
+                $cookies['uid'] = v
+            end
+
+            opts.on('-u', '--username USERNAME', 'Download all posts from a Medium username') do |v|
+                options[:username] = v
+            end
+
+            opts.on('-p', '--postURL POST_URL', 'Download a single post URL') do |v|
+                options[:postURL] = v
+            end
+
+            opts.on('--jekyll', 'Emit Jekyll-friendly output (combine with -u or -p)') do
+                options[:jekyll] = true
+            end
+
+            opts.on('-j', '--jekyllUsername USERNAME', 'DEPRECATED: use `--jekyll -u USERNAME`') do |v|
+                options[:username] = v
+                options[:jekyll] = true
+                errput.puts '[deprecated] -j/--jekyllUsername is deprecated; use `--jekyll -u USERNAME`.'
+            end
+
+            opts.on('-k', '--jekyllPostURL POST_URL', 'DEPRECATED: use `--jekyll -p POST_URL`') do |v|
+                options[:postURL] = v
+                options[:jekyll] = true
+                errput.puts '[deprecated] -k/--jekyllPostURL is deprecated; use `--jekyll -p POST_URL`.'
+            end
+
+            opts.on('-n', '--new', 'Update to latest version') do
+                options[:upgrade] = true
+            end
+
+            opts.on('-c', '--clean', 'Remove all downloaded posts data under cwd') do
+                options[:clean] = true
+            end
+
+            opts.on('-v', '--version', 'Print current ZMediumToMarkdown version') do
+                options[:version] = true
+            end
+
+            opts.on('-h', '--help', 'Show this help message') do
+                options[:help] = opts.to_s
+            end
+        end
+
+        parser.parse!(argv)
+        options
+    end
+
+    def loadCookiesFromEnv!
+        $cookies['sid'] = ENV['MEDIUM_COOKIE_SID'] if cookieMissing?('sid') && !ENV['MEDIUM_COOKIE_SID'].to_s.empty?
+        $cookies['uid'] = ENV['MEDIUM_COOKIE_UID'] if cookieMissing?('uid') && !ENV['MEDIUM_COOKIE_UID'].to_s.empty?
+    end
+
+    def cookieMissing?(name)
+        return true unless defined?($cookies) && $cookies.is_a?(Hash)
+        $cookies[name].to_s.empty?
+    end
+
+    def cookiesPresent?
+        !cookieMissing?('sid') || !cookieMissing?('uid')
+    end
+
+    # Only warn when the invocation will actually hit Medium - skip for
+    # --version, --clean, --help, --new.
+    def warnIfNoCookies(options, errput: $stderr)
+        return if cookiesPresent?
+        return unless willHitMedium?(options)
+        errput.puts COOKIE_WARNING_BANNER
+    end
+
+    def willHitMedium?(options)
+        !options[:postURL].nil? || !options[:username].nil?
+    end
+
+    def run(options, cwd, output: $stdout)
+        if options[:help]
+            output.puts options[:help]
+            return
+        end
+
+        if options[:version]
+            output.puts "Version:#{Helper.getLocalVersion()}"
+            Helper.printNewVersionMessageIfExists()
+            return
+        end
+
+        if options[:clean]
+            outputFilePath = PathPolicy.new(cwd, "")
+            FileUtils.rm_rf(Dir[outputFilePath.getAbsolutePath(nil)])
+            output.puts "All downloaded posts data has been removed."
+            Helper.printNewVersionMessageIfExists()
+            return
+        end
+
+        if options[:upgrade]
+            remote = Helper.getRemoteVersionFromGithub()
+            local  = Helper.getLocalVersion()
+            if remote && local && remote > local
+                Helper.downloadLatestVersion()
+            else
+                output.puts "You're using the latest version :)"
+            end
+            return
+        end
+
+        return unless willHitMedium?(options)
+
+        fetcher = ZMediumFetcher.new
+        fetcher.isForJekyll = options[:jekyll] == true
+
+        targetPolicy = pathPolicyFor(cwd, fetcher.isForJekyll)
+
+        if options[:postURL]
+            fetcher.downloadPost(options[:postURL], targetPolicy, nil)
+        elsif options[:username]
+            fetcher.downloadPostsByUsername(options[:username], targetPolicy)
+        end
+
+        Helper.printNewVersionMessageIfExists()
+    end
+
+    # Jekyll mode writes into the cwd (so files land in `_posts/...` and
+    # `assets/...` of an existing Jekyll site). Plain mode nests under
+    # `Output/` to keep the user's cwd tidy.
+    def pathPolicyFor(cwd, isForJekyll)
+        if isForJekyll
+            PathPolicy.new(cwd, "")
+        else
+            PathPolicy.new("#{cwd}/Output", "Output")
+        end
+    end
+end

--- a/lib/Parsers/IframeParser.rb
+++ b/lib/Parsers/IframeParser.rb
@@ -12,11 +12,21 @@ require 'PathPolicy'
 class IframeParser < Parser
     attr_accessor :nextParser, :pathPolicy, :isForJekyll
 
-    YOUTUBE_HOST = "www.youtube.com".freeze
-    GIST_HOST_REGEX = /^(https\:\/\/gist\.github\.com)/.freeze
-    EMBEDLY_HOST_REGEX = /(cdn\.embedly\.com)/.freeze
-    TWITTER_URL_REGEX = /^(https\:\/\/twitter\.com\/){1}.+(\/){1}(\d+)/.freeze
-    WIDGETIC_URL_REGEX = /^(https\:\/\/app\.widgetic\.com)/.freeze
+    GIST_HOST_REGEX     = /^https:\/\/gist\.github\.com/.freeze
+    EMBEDLY_HOST_REGEX  = /cdn\.embedly\.com/.freeze
+
+    # Twitter rebranded to X — match both, plus the mobile subdomain. Capture
+    # group 1 is the tweet ID (used by parseTwitterEmbed).
+    TWITTER_URL_REGEX   = /^https:\/\/(?:(?:mobile\.)?twitter|x)\.com\/[^\/]+\/status\/(\d+)/.freeze
+
+    # Match every YouTube URL form Medium might hand us:
+    #   www.youtube.com/watch?v=ID    youtu.be/ID    youtube.com/shorts/ID    m.youtube.com/...
+    YOUTUBE_HOST_REGEX  = /(?:www\.|m\.)?youtube\.com|youtu\.be/.freeze
+
+    VIMEO_URL_REGEX     = /^https?:\/\/(?:www\.|player\.)?vimeo\.com\/(?:video\/)?(\d+)/.freeze
+    SOUNDCLOUD_URL_REGEX = /^https?:\/\/(?:www\.)?soundcloud\.com\/[^\/]+\/[^?\/]+/.freeze
+    SPOTIFY_URL_REGEX   = /^https?:\/\/open\.spotify\.com\/(track|album|episode|playlist|show)\/([A-Za-z0-9]+)/.freeze
+    WIDGETIC_URL_REGEX  = /^https:\/\/app\.widgetic\.com/.freeze
 
     def initialize(isForJekyll)
         @isForJekyll = isForJekyll
@@ -32,14 +42,18 @@ class IframeParser < Parser
                   paragraph.iframe.src
               end
 
-        return parseYoutube(paragraph, url) if url.match?(/(www\.youtube\.com)/)
+        return parseYoutube(paragraph, url) if url.match?(YOUTUBE_HOST_REGEX)
 
         # Resolve embedly wrappers up front so we can dispatch on the inner
         # URL without doing an unnecessary HTTP round-trip for hosts we
-        # already know how to handle (twitter, widgetic).
+        # already know how to handle.
         innerURL = unwrapEmbedly(url)
-        return parseTwitterEmbed(paragraph, innerURL) if innerURL.match?(TWITTER_URL_REGEX)
-        return nil if innerURL.match?(WIDGETIC_URL_REGEX)
+
+        return parseTwitterEmbed(paragraph, innerURL)         if innerURL.match?(TWITTER_URL_REGEX)
+        return nil                                            if innerURL.match?(WIDGETIC_URL_REGEX)
+        return parseVimeo(paragraph, url, innerURL)           if innerURL.match?(VIMEO_URL_REGEX)
+        return parseSoundCloud(paragraph, innerURL)           if innerURL.match?(SOUNDCLOUD_URL_REGEX)
+        return parseSpotify(paragraph, innerURL)              if innerURL.match?(SPOTIFY_URL_REGEX)
 
         html = Request.html(Request.URL(url))
         return "" unless html
@@ -66,14 +80,20 @@ class IframeParser < Parser
 
     def unwrapEmbedly(url)
         return url unless url.match?(EMBEDLY_HOST_REGEX)
-        params = URI.decode_www_form(URI(decodeURL(url)).query || "").to_h
+        params = embedlyParams(url)
         params["url"] || url
+    end
+
+    # Decodes a `cdn.embedly.com` URL and returns its query params hash.
+    # Returns {} on any parse failure so callers can branch with `params["url"]`.
+    def embedlyParams(url)
+        URI.decode_www_form(URI(decodeURL(url)).query || "").to_h
     rescue URI::InvalidURIError, ArgumentError
-        url
+        {}
     end
 
     def parseTwitterEmbed(paragraph, ogURL)
-        twitterID = ogURL[TWITTER_URL_REGEX, 3]
+        twitterID = ogURL[TWITTER_URL_REGEX, 1]
         return plainLink(paragraph, ogURL) if twitterID.nil?
 
         TwitterEmbed.render(twitterID, ogURL, jekyllOpen: jekyllOpen) ||
@@ -86,30 +106,108 @@ class IframeParser < Parser
         "[#{title}](#{ogURL})#{jekyllOpen}"
     end
 
+    # YouTube: in Jekyll mode emit a <iframe> player; in plain mode download
+    # the embedly-provided thumbnail and emit `[![title](thumb)](videoURL)`.
     def parseYoutube(paragraph, url)
-        youtubeURL = URI(decodeURL(url)).query
-        params = URI.decode_www_form(youtubeURL || "").to_h
-        return "[#{paragraph.iframe.title}](#{url})#{jekyllOpen}" if params["url"].nil?
+        params = embedlyParams(url)
+        targetURL = params["url"] || url
+        return plainLink(paragraph, targetURL) if params["url"].nil?
 
         if isForJekyll
-            vidParams = URI.decode_www_form(URI.parse(params["url"]).query || "").to_h
-            vid = vidParams["v"]
-            "<iframe class=\"embed-video\" loading=\"lazy\" src=\"https://www.youtube.com/embed/#{vid}\" title=\"#{paragraph.iframe.title}\" frameborder=\"0\" allow=\"accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture\" allowfullscreen ></iframe>"
+            vid = extractYoutubeVideoID(targetURL)
+            return plainLink(paragraph, targetURL) if vid.nil? || vid.empty?
+            iframeMarkup("https://www.youtube.com/embed/#{vid}", paragraph.iframe.title || "Youtube",
+                         allow: "accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture")
         else
-            return "[#{paragraph.iframe.title}](#{url})#{jekyllOpen}" if params["image"].nil?
+            return plainLink(paragraph, targetURL) if params["image"].nil?
+            renderThumbnailLink(paragraph, targetURL, params["image"], defaultTitle: "Youtube")
+        end
+    end
 
-            fileName = "#{paragraph.name}_#{URI(params["image"]).path.split("/").last}"
-            imagePathPolicy = PathPolicy.new(pathPolicy.getAbsolutePath(paragraph.postID), pathPolicy.getRelativePath(paragraph.postID))
-            absolutePath = imagePathPolicy.getAbsolutePath(fileName)
-            title = paragraph.iframe.title
-            title = "Youtube" if title.nil? || title == ""
+    # YouTube IDs live in three places depending on URL form:
+    #   ?v=<id>            (canonical /watch?v=...)
+    #   /<id>              (youtu.be short links)
+    #   /shorts/<id>       (YouTube Shorts)
+    def extractYoutubeVideoID(url)
+        uri = URI.parse(url)
+        return nil unless uri && uri.host
 
-            if ImageDownloader.download(absolutePath, params["image"])
-                relativePath = imagePathPolicy.getRelativePath(fileName)
-                "\r\n\r\n[![#{title}](#{relativePath} \"#{title}\")](#{params["url"]})#{jekyllOpen}\r\n\r\n"
-            else
-                "\r\n[#{title}](#{params["url"]})#{jekyllOpen}\r\n"
-            end
+        if uri.host.include?('youtu.be')
+            uri.path.delete_prefix('/').split('/').first
+        elsif uri.path.start_with?('/shorts/')
+            uri.path.delete_prefix('/shorts/').split('/').first
+        else
+            URI.decode_www_form(uri.query || '').to_h['v']
+        end
+    rescue URI::InvalidURIError
+        nil
+    end
+
+    # Vimeo: same pattern as YouTube. Embedly tends to ship a thumbnail in
+    # the `image` query param; if it's missing we fall back to og:image.
+    def parseVimeo(paragraph, embedlyURL, innerURL)
+        if isForJekyll
+            vid = innerURL[VIMEO_URL_REGEX, 1]
+            return plainLink(paragraph, innerURL) if vid.nil?
+            iframeMarkup("https://player.vimeo.com/video/#{vid}", paragraph.iframe.title || "Vimeo",
+                         allow: "autoplay; fullscreen; picture-in-picture", aspectClass: "embed-video")
+        else
+            params = embedlyParams(embedlyURL)
+            imageURL = params["image"]
+            imageURL = Helper.fetchOGImage(innerURL) if imageURL.nil? || imageURL.empty?
+            return plainLink(paragraph, innerURL) if imageURL.nil? || imageURL.empty?
+            renderThumbnailLink(paragraph, innerURL, imageURL, defaultTitle: "Vimeo")
+        end
+    end
+
+    # SoundCloud: Jekyll mode emits the official iframe player; plain mode
+    # has no audio embed option, so we render the OG image card if available
+    # and fall back to a plain link.
+    def parseSoundCloud(paragraph, innerURL)
+        if isForJekyll
+            playerURL = "https://w.soundcloud.com/player/?url=#{URI.encode_www_form_component(innerURL)}&color=%23ff5500&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true"
+            iframeMarkup(playerURL, paragraph.iframe.title || "SoundCloud",
+                         allow: "autoplay", aspectClass: "embed-audio")
+        else
+            parseOgImageEmbed(paragraph, innerURL)
+        end
+    end
+
+    # Spotify: Jekyll mode emits the official open.spotify.com/embed iframe;
+    # plain mode falls through to OG image / link.
+    def parseSpotify(paragraph, innerURL)
+        if isForJekyll
+            kind = innerURL[SPOTIFY_URL_REGEX, 1]
+            id   = innerURL[SPOTIFY_URL_REGEX, 2]
+            return plainLink(paragraph, innerURL) if kind.nil? || id.nil?
+            iframeMarkup("https://open.spotify.com/embed/#{kind}/#{id}", paragraph.iframe.title || "Spotify",
+                         allow: "encrypted-media", aspectClass: "embed-audio")
+        else
+            parseOgImageEmbed(paragraph, innerURL)
+        end
+    end
+
+    # Generic Jekyll <iframe> markup used by every video / audio embed.
+    def iframeMarkup(src, title, allow:, aspectClass: "embed-video")
+        "<iframe class=\"#{aspectClass}\" loading=\"lazy\" src=\"#{src}\" title=\"#{title}\" frameborder=\"0\" allow=\"#{allow}\" allowfullscreen ></iframe>"
+    end
+
+    # Downloads `imageURL` into the post asset directory and emits the
+    # standard `[![title](relPath)](targetURL)` markdown. Falls back to a
+    # plain link if the download fails.
+    def renderThumbnailLink(paragraph, targetURL, imageURL, defaultTitle:)
+        fileName = "#{paragraph.name}_#{URI(imageURL).path.split("/").last}"
+        imagePolicy = PathPolicy.new(pathPolicy.getAbsolutePath(paragraph.postID), pathPolicy.getRelativePath(paragraph.postID))
+        absolutePath = imagePolicy.getAbsolutePath(fileName)
+
+        title = paragraph.iframe.title
+        title = defaultTitle if title.nil? || title.empty?
+
+        if ImageDownloader.download(absolutePath, imageURL)
+            relativePath = imagePolicy.getRelativePath(fileName)
+            "\r\n\r\n[![#{title}](#{relativePath} \"#{title}\")](#{targetURL})#{jekyllOpen}\r\n\r\n"
+        else
+            "\r\n[#{title}](#{targetURL})#{jekyllOpen}\r\n"
         end
     end
 

--- a/lib/Parsers/IframeParser.rb
+++ b/lib/Parsers/IframeParser.rb
@@ -3,6 +3,7 @@ require 'nokogiri'
 
 require 'Request'
 require 'Parsers/Parser'
+require 'Parsers/TwitterEmbed'
 require 'Models/Paragraph'
 require 'Helper'
 require 'ImageDownloader'
@@ -33,6 +34,13 @@ class IframeParser < Parser
 
         return parseYoutube(paragraph, url) if url.match?(/(www\.youtube\.com)/)
 
+        # Resolve embedly wrappers up front so we can dispatch on the inner
+        # URL without doing an unnecessary HTTP round-trip for hosts we
+        # already know how to handle (twitter, widgetic).
+        innerURL = unwrapEmbedly(url)
+        return parseTwitterEmbed(paragraph, innerURL) if innerURL.match?(TWITTER_URL_REGEX)
+        return nil if innerURL.match?(WIDGETIC_URL_REGEX)
+
         html = Request.html(Request.URL(url))
         return "" unless html
 
@@ -42,7 +50,7 @@ class IframeParser < Parser
         if gistSrc.match?(GIST_HOST_REGEX)
             parseGist(gistSrc)
         else
-            parseGenericEmbed(paragraph, url)
+            parseOgImageEmbed(paragraph, innerURL)
         end
     end
 
@@ -54,6 +62,28 @@ class IframeParser < Parser
 
     def forwardToNext(paragraph)
         nextParser&.parse(paragraph)
+    end
+
+    def unwrapEmbedly(url)
+        return url unless url.match?(EMBEDLY_HOST_REGEX)
+        params = URI.decode_www_form(URI(decodeURL(url)).query || "").to_h
+        params["url"] || url
+    rescue URI::InvalidURIError, ArgumentError
+        url
+    end
+
+    def parseTwitterEmbed(paragraph, ogURL)
+        twitterID = ogURL[TWITTER_URL_REGEX, 3]
+        return plainLink(paragraph, ogURL) if twitterID.nil?
+
+        TwitterEmbed.render(twitterID, ogURL, jekyllOpen: jekyllOpen) ||
+            plainLink(paragraph, ogURL)
+    end
+
+    def plainLink(paragraph, ogURL)
+        title = paragraph.iframe.title
+        title = ogURL if title.nil? || title.empty?
+        "[#{title}](#{ogURL})#{jekyllOpen}"
     end
 
     def parseYoutube(paragraph, url)
@@ -118,22 +148,7 @@ class IframeParser < Parser
         nil
     end
 
-    def parseGenericEmbed(paragraph, url)
-        ogURL = url
-        if url.match?(EMBEDLY_HOST_REGEX)
-            params = URI.decode_www_form(URI(decodeURL(url)).query || "").to_h
-            ogURL = params["url"] if params["url"]
-        end
-
-        # The Twitter v1.1 statuses/show endpoint we used to call here is dead;
-        # render twitter URLs as a plain link instead of trying to embed.
-        if ogURL.match?(TWITTER_URL_REGEX)
-            return "[#{paragraph.iframe.title}](#{ogURL})#{jekyllOpen}"
-        end
-
-        # Skip widgetic embeds (they don't render usefully as static markdown).
-        return nil if ogURL.match?(WIDGETIC_URL_REGEX)
-
+    def parseOgImageEmbed(paragraph, ogURL)
         ogImageURL = Helper.fetchOGImage(ogURL)
         title = paragraph.iframe.title
         title = Helper.escapeMarkdown(ogURL) if title.nil? || title == ""

--- a/lib/Parsers/TwitterEmbed.rb
+++ b/lib/Parsers/TwitterEmbed.rb
@@ -1,0 +1,115 @@
+require 'json'
+require 'time'
+require 'uri'
+
+require 'Helper'
+require 'Request'
+
+# Embeds a single tweet by hitting Twitter's syndication endpoint
+# (https://cdn.syndication.twitter.com/tweet-result), the same API
+# used by Twitter's own publish widget and by libraries like
+# vercel/react-tweet. Returns a markdown blockquote, or `nil` on
+# any fetch / parse failure so the caller can fall back to a plain
+# link without raising.
+module TwitterEmbed
+    SYNDICATION_HOST = ENV.fetch('TWITTER_SYNDICATION_HOST', 'https://cdn.syndication.twitter.com').freeze
+
+    # Public: fetches a tweet payload and renders it as markdown.
+    # Returns nil if the request, JSON parse, or render fails for any reason.
+    def self.render(tweetID, tweetURL, jekyllOpen: '')
+        tweet = fetch(tweetID)
+        return nil if tweet.nil?
+        renderMarkdown(tweet, tweetURL, jekyllOpen: jekyllOpen)
+    rescue StandardError
+        nil
+    end
+
+    def self.fetch(tweetID)
+        url = "#{SYNDICATION_HOST}/tweet-result?id=#{tweetID}&token=#{generateToken(tweetID)}&lang=en"
+        body = Request.body(Request.URL(url))
+        return nil if body.nil? || body.empty?
+        JSON.parse(body)
+    rescue StandardError
+        nil
+    end
+
+    # Token derivation matching Twitter's publish widget / react-tweet:
+    # https://github.com/vercel/react-tweet/blob/main/packages/api/src/api/fetch-tweet.ts#L8
+    #   ((Number(id) / 1e15) * Math.PI).toString(36).replace(/(0+|\.)/g, '')
+    def self.generateToken(tweetID)
+        floatToBase36((tweetID.to_f / 1e15) * Math::PI).gsub(/(0+|\.)/, '')
+    end
+
+    # Ruby's Float#to_s has no base argument, so we hand-roll the
+    # JS Number#toString(36) format (whole.fractional in base-36).
+    def self.floatToBase36(num)
+        whole = num.to_i
+        frac  = num - whole
+        out   = whole.to_s(36)
+        return out if frac.zero?
+
+        out += '.'
+        16.times do
+            break if frac.zero?
+            frac *= 36
+            digit = frac.to_i
+            frac -= digit
+            out += digit.to_s(36)
+        end
+        out
+    end
+
+    def self.renderMarkdown(tweet, tweetURL, jekyllOpen: '')
+        return nil unless tweet.is_a?(Hash)
+
+        text = expandEntities(tweet)
+        name = tweet.dig('user', 'name') || tweet.dig('user', 'screen_name') || 'Twitter User'
+        screen = tweet.dig('user', 'screen_name')
+        date = formatDate(tweet['created_at'])
+
+        author_link = screen ? "https://twitter.com/#{screen}" : tweetURL
+
+        out = "\n\n"
+        out += "■■■■■■■■■■■■■■ \n"
+        out += "> **[#{name}](#{author_link})#{jekyllOpen} @ Twitter Says:** \n\n"
+        out += "> > #{text} \n\n"
+        out += "> **Tweeted at [#{date}](#{tweetURL})#{jekyllOpen}.** \n\n"
+        out += "■■■■■■■■■■■■■■ \n\n"
+        out
+    end
+
+    # Replaces shortened t.co URLs and @-mentions in the tweet body with
+    # markdown links. Mirrors the original v1.1 behaviour so existing
+    # downstream renderers don't see a behavioural change.
+    def self.expandEntities(tweet)
+        text = (tweet['text'] || '').dup
+
+        Array(tweet.dig('entities', 'urls')).each do |u|
+            short = u['url']
+            next if short.nil? || short.empty?
+            display  = u['display_url']
+            expanded = u['expanded_url'] || short
+            label = display && !display.empty? ? display : expanded
+            text = text.gsub(short, "[#{label}](#{expanded})")
+        end
+
+        Array(tweet.dig('entities', 'user_mentions')).each do |mention|
+            screen = mention['screen_name']
+            next if screen.nil? || screen.empty?
+            # Word-boundary-ish replace so we don't mangle substrings.
+            text = text.gsub(/@?#{Regexp.escape(screen)}\b/) do |match|
+                prefix = match.start_with?('@') ? '@' : ''
+                "#{prefix}[#{screen}](https://twitter.com/#{screen})"
+            end
+        end
+
+        text
+    end
+
+    def self.formatDate(value)
+        return '' if value.nil? || value.to_s.empty?
+        Time.parse(value.to_s).strftime('%Y-%m-%d %H:%M:%S')
+    rescue ArgumentError
+        value.to_s
+    end
+end

--- a/lib/Request.rb
+++ b/lib/Request.rb
@@ -2,9 +2,46 @@ require 'net/http'
 require 'nokogiri'
 
 class Request
+    # Raised when Medium's Cloudflare layer blocks the request (typically
+    # the "Just a moment..." challenge page). Carries enough context for
+    # the CLI to print actionable cookie-setup guidance.
+    class CloudflareBlockedError < StandardError
+        attr_reader :http_code, :url
+
+        def initialize(http_code, url)
+            @http_code = http_code
+            @url = url
+            super(buildMessage)
+        end
+
+        private
+
+        def buildMessage
+            <<~MSG.strip
+              Blocked by Medium's Cloudflare layer (HTTP #{http_code}) at #{url}.
+
+              This usually means the request was made from an environment Cloudflare
+              treats as a bot (cloud runners, datacenter IPs, headless browsers) and
+              no logged-in Medium cookie was provided.
+
+              Fix:
+                1. Open https://medium.com in a logged-in browser.
+                2. Open DevTools -> Application/Storage -> Cookies -> medium.com.
+                3. Copy the values of the `sid` and `uid` cookies.
+                4. Re-run with:    -s YOUR_SID -d YOUR_UID
+                   or via env:     MEDIUM_COOKIE_SID=... MEDIUM_COOKIE_UID=...
+
+              Background and a Cloudflare Worker proxy workaround:
+              https://zhgchg.li/posts/zrealm-dev/medium-api-%E7%88%AC%E5%8F%96%E8%B3%87%E6%96%99%E8%88%87%E7%AA%81%E7%A0%B4-cloudflare-%E9%98%B2%E8%AD%B7-%E5%AE%8C%E6%95%B4-graphql-%E6%93%8D%E4%BD%9C%E6%95%99%E5%AD%B8-88f0fb935120/
+            MSG
+        end
+    end
+
+    CLOUDFLARE_MITIGATION_VALUES = %w[challenge block managed_challenge].freeze
+
     def self.URL(url, method = 'GET', data = nil, retryCount = 0)
         retryCount += 1
-        
+
         uri = URI(url)
         https = Net::HTTP.new(uri.host, uri.port)
         https.use_ssl = true
@@ -47,7 +84,7 @@ class Request
         end
 
         request['User-Agent'] = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0';
-        
+
         cookiesString = $cookies.reject { |_, value| value.nil? }
         .map { |key, value| "#{key}=#{value}" }
         .join("; ");
@@ -57,7 +94,7 @@ class Request
         end
 
         response = https.request(request);
-          
+
         setCookieString = response.get_fields('set-cookie');
         if !setCookieString.nil? && setCookieString != ""
           setCookies = setCookieString.map { |cookie| cookie.split('; ').first }.each_with_object({}) do |cookie, hash|
@@ -70,10 +107,12 @@ class Request
           end
         end
 
+        raise CloudflareBlockedError.new(response.code.to_i, url) if cloudflareBlocked?(response)
+
         # 3XX Redirect
         if response.code.to_i == 429
           if retryCount >= 10
-            raise "Error: Too Manay Reqeust, blocked by Medium. URL: #{url}";
+            raise "Error: Too Many Requests, blocked by Medium. URL: #{url}"
           else
             response = self.URL(url, method, data, retryCount);
           end
@@ -85,12 +124,31 @@ class Request
                 if !location.match? /^(http)/
                     location = "#{uri.scheme}://#{uri.host}#{location}"
                 end
-                
+
                 response = self.URL(location, method, data, retryCount)
             end
         end
-        
+
         response
+    end
+
+    # Cloudflare tags blocked responses via either the cf-mitigated header
+    # or the standard "Just a moment..." challenge HTML. We check both
+    # so we catch challenges even on Cloudflare deployments that don't
+    # set the explicit header.
+    def self.cloudflareBlocked?(response)
+        return false if response.nil?
+        code = response.code.to_i
+        return false unless code == 403 || code == 503
+
+        mitigated = response['cf-mitigated'].to_s.downcase
+        return true if CLOUDFLARE_MITIGATION_VALUES.include?(mitigated)
+
+        body = response.body.to_s
+        return false if body.empty?
+        body.include?('Just a moment...') ||
+            body.include?('cf-error-details') ||
+            body.include?('Attention Required')
     end
 
     def self.html(response)

--- a/lib/ZMediumFetcher.rb
+++ b/lib/ZMediumFetcher.rb
@@ -183,7 +183,7 @@ class ZMediumFetcher
             FileUtils.touch absolutePath, :mtime => postInfo.latestPublishedAt
 
             progress.message = if isLockedPreviewOnly
-                                   "This post is behind Medium's paywall. You need to provide valid Medium Member login cookies to download the full post."
+                                   paywallMessage
                                else
                                    "Post Successfully Downloaded!"
                                end
@@ -265,6 +265,17 @@ class ZMediumFetcher
         meta[:lockedPreviewOnly] = lockedLine[/^(lockedPreviewOnly:)\s+(\S*)/, 2].to_s.downcase == "true" if lockedLine
 
         meta
+    end
+
+    # Wording branches on whether the user supplied Medium auth cookies, so
+    # they get an actionable next step: provide cookies vs. check that
+    # cookies belong to a Medium Member account that has access to the post.
+    def paywallMessage
+        if !defined?($cookies) || $cookies.nil? || ($cookies['sid'].to_s.empty? && $cookies['uid'].to_s.empty?)
+            "This post is behind Medium's paywall. Provide your Medium Member cookies (-s SID -d UID) to download the full content. See README -> Cookie setup."
+        else
+            "This post is behind Medium's paywall and the provided cookies don't grant access. Verify your sid/uid belong to a Medium Member account that can read this post (cookies expire roughly every 2 weeks)."
+        end
     end
 
     # Runs MarkupParser (when applicable) and the parser chain on a single

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -1,0 +1,158 @@
+require_relative 'test_helper'
+require 'stringio'
+
+class CLIParseArgsTest < Minitest::Test
+  def setup
+    $cookies = {}
+    @err = StringIO.new
+  end
+
+  def parse(args)
+    CLI.parseArgs(args.dup, errput: @err)
+  end
+
+  def test_username_flag_sets_username
+    opts = parse(%w[-u alice])
+    assert_equal 'alice', opts[:username]
+    refute opts[:jekyll]
+  end
+
+  def test_post_url_flag_sets_post_url
+    opts = parse(%w[-p https://medium.com/p/abc])
+    assert_equal 'https://medium.com/p/abc', opts[:postURL]
+    refute opts[:jekyll]
+  end
+
+  def test_jekyll_modifier_with_username_does_not_warn
+    opts = parse(%w[-u alice --jekyll])
+    assert_equal 'alice', opts[:username]
+    assert_equal true, opts[:jekyll]
+    assert_empty @err.string
+  end
+
+  def test_jekyll_modifier_with_post_url
+    opts = parse(['-p', 'https://medium.com/p/abc', '--jekyll'])
+    assert_equal 'https://medium.com/p/abc', opts[:postURL]
+    assert_equal true, opts[:jekyll]
+  end
+
+  def test_deprecated_jekyll_username_still_works_and_warns
+    opts = parse(%w[-j alice])
+    assert_equal 'alice', opts[:username]
+    assert_equal true, opts[:jekyll]
+    assert_match(/deprecated/, @err.string)
+    assert_match(/--jekyll -u USERNAME/, @err.string)
+  end
+
+  def test_deprecated_jekyll_post_url_still_works_and_warns
+    opts = parse(['-k', 'https://medium.com/p/abc'])
+    assert_equal 'https://medium.com/p/abc', opts[:postURL]
+    assert_equal true, opts[:jekyll]
+    assert_match(/deprecated/, @err.string)
+    assert_match(/--jekyll -p POST_URL/, @err.string)
+  end
+
+  def test_cookie_flags_populate_cookie_jar
+    parse(%w[-s sid_value -d uid_value])
+    assert_equal 'sid_value', $cookies['sid']
+    assert_equal 'uid_value', $cookies['uid']
+  end
+
+  def test_help_flag_returns_options_with_help_text
+    opts = parse(%w[-h])
+    refute_nil opts[:help]
+    assert_includes opts[:help], '-s, --cookie_sid'
+    assert_includes opts[:help], '--jekyll'
+  end
+
+  def test_version_flag
+    opts = parse(%w[-v])
+    assert_equal true, opts[:version]
+  end
+
+  def test_clean_flag
+    opts = parse(%w[-c])
+    assert_equal true, opts[:clean]
+  end
+
+  def test_upgrade_flag
+    opts = parse(%w[-n])
+    assert_equal true, opts[:upgrade]
+  end
+end
+
+class CLICookieEnvTest < Minitest::Test
+  def setup
+    $cookies = {}
+    @prev_sid = ENV['MEDIUM_COOKIE_SID']
+    @prev_uid = ENV['MEDIUM_COOKIE_UID']
+    ENV.delete('MEDIUM_COOKIE_SID')
+    ENV.delete('MEDIUM_COOKIE_UID')
+  end
+
+  def teardown
+    ENV['MEDIUM_COOKIE_SID'] = @prev_sid
+    ENV['MEDIUM_COOKIE_UID'] = @prev_uid
+  end
+
+  def test_loads_sid_and_uid_from_env_when_unset
+    ENV['MEDIUM_COOKIE_SID'] = 'env_sid'
+    ENV['MEDIUM_COOKIE_UID'] = 'env_uid'
+    CLI.loadCookiesFromEnv!
+    assert_equal 'env_sid', $cookies['sid']
+    assert_equal 'env_uid', $cookies['uid']
+  end
+
+  def test_cli_flags_take_precedence_over_env
+    ENV['MEDIUM_COOKIE_SID'] = 'env_sid'
+    $cookies['sid'] = 'cli_sid'
+    CLI.loadCookiesFromEnv!
+    assert_equal 'cli_sid', $cookies['sid']
+  end
+
+  def test_empty_env_value_is_ignored
+    ENV['MEDIUM_COOKIE_SID'] = ''
+    CLI.loadCookiesFromEnv!
+    assert CLI.cookieMissing?('sid')
+  end
+end
+
+class CLIWarningTest < Minitest::Test
+  def setup
+    $cookies = {}
+    @err = StringIO.new
+  end
+
+  def test_warns_when_post_url_set_and_no_cookies
+    CLI.warnIfNoCookies({ postURL: 'https://medium.com/p/abc' }, errput: @err)
+    assert_match(/Medium login cookie/, @err.string)
+    assert_match(/MEDIUM_COOKIE_SID/, @err.string)
+  end
+
+  def test_warns_when_username_set_and_no_cookies
+    CLI.warnIfNoCookies({ username: 'alice' }, errput: @err)
+    assert_match(/Medium login cookie/, @err.string)
+  end
+
+  def test_does_not_warn_when_only_sid_present
+    $cookies['sid'] = 'x'
+    CLI.warnIfNoCookies({ postURL: 'https://medium.com/p/abc' }, errput: @err)
+    assert_empty @err.string
+  end
+
+  def test_does_not_warn_when_only_uid_present
+    $cookies['uid'] = 'x'
+    CLI.warnIfNoCookies({ postURL: 'https://medium.com/p/abc' }, errput: @err)
+    assert_empty @err.string
+  end
+
+  def test_does_not_warn_for_version_only_invocations
+    CLI.warnIfNoCookies({ version: true }, errput: @err)
+    assert_empty @err.string
+  end
+
+  def test_does_not_warn_for_clean_only_invocations
+    CLI.warnIfNoCookies({ clean: true }, errput: @err)
+    assert_empty @err.string
+  end
+end

--- a/test/iframe_parser_embeds_test.rb
+++ b/test/iframe_parser_embeds_test.rb
@@ -1,0 +1,249 @@
+require_relative 'test_helper'
+
+# Helpers and shared setup for embedly handler tests.
+module IframeParserTestSupport
+  def make_iframe_paragraph(iframe_src, title: 'embed', id: 'eid')
+    TestSupport.paragraph(
+      type: 'IFRAME',
+      iframe: { 'mediaResource' => { 'iframeSrc' => iframe_src, 'title' => title, 'id' => id } }
+    )
+  end
+
+  def parser
+    p = IframeParser.new(@isForJekyll || false)
+    p.pathPolicy = PathPolicy.new('/abs', 'rel')
+    p
+  end
+
+  def stub_no_network
+    Request.stub(:URL, nil) do
+      Request.stub(:html, nil) do
+        Request.stub(:body, nil) do
+          ImageDownloader.stub(:download, true) do
+            Helper.stub(:fetchOGImage, '') do
+              yield
+            end
+          end
+        end
+      end
+    end
+  end
+end
+
+class IframeXTwitterDispatchTest < Minitest::Test
+  include IframeParserTestSupport
+
+  def test_xcom_url_dispatches_through_twitter_embed
+    paragraph = make_iframe_paragraph('https://x.com/alice/status/1700000000000000001')
+    fake = '{"text":"hello x","user":{"name":"Alice","screen_name":"alice"},"created_at":"2024-01-15T10:30:00.000Z"}'
+    Request.stub(:URL, nil) do
+      Request.stub(:body, fake) do
+        out = parser.parse(paragraph)
+        assert_includes out, '> > hello x'
+        assert_includes out, '[Alice](https://twitter.com/alice)'
+      end
+    end
+  end
+
+  def test_mobile_twitter_url_dispatches_through_twitter_embed
+    paragraph = make_iframe_paragraph('https://mobile.twitter.com/alice/status/1700000000000000002')
+    fake = '{"text":"mobile","user":{"name":"Alice","screen_name":"alice"},"created_at":"2024-01-15T10:30:00.000Z"}'
+    Request.stub(:URL, nil) do
+      Request.stub(:body, fake) do
+        out = parser.parse(paragraph)
+        assert_includes out, '> > mobile'
+      end
+    end
+  end
+
+  def test_embedly_wrapped_xcom_url_dispatches_through_twitter_embed
+    embedly = 'https://cdn.embedly.com/widgets/media.html?src=foo&url=https%3A%2F%2Fx.com%2Falice%2Fstatus%2F1700000000000000003&type=text%2Fhtml'
+    paragraph = make_iframe_paragraph(embedly)
+    fake = '{"text":"unwrapped x","user":{"name":"A","screen_name":"a"},"created_at":"2024-01-15T10:30:00.000Z"}'
+    Request.stub(:URL, nil) do
+      Request.stub(:body, fake) do
+        out = parser.parse(paragraph)
+        assert_includes out, 'unwrapped x'
+      end
+    end
+  end
+end
+
+class IframeYoutubeVariantsTest < Minitest::Test
+  include IframeParserTestSupport
+
+  def test_youtu_be_short_url_extracts_video_id_in_jekyll
+    @isForJekyll = true
+    embedly = 'https://cdn.embedly.com/widgets/media.html?src=foo&url=https%3A%2F%2Fyoutu.be%2FdQw4w9WgXcQ&image=https%3A%2F%2Fimg.youtube.com%2Fthumb.jpg&type=text%2Fhtml'
+    paragraph = make_iframe_paragraph(embedly)
+    out = parser.parse(paragraph)
+    assert_includes out, 'src="https://www.youtube.com/embed/dQw4w9WgXcQ"'
+  end
+
+  def test_youtube_shorts_url_extracts_video_id_in_jekyll
+    @isForJekyll = true
+    embedly = 'https://cdn.embedly.com/widgets/media.html?src=foo&url=https%3A%2F%2Fwww.youtube.com%2Fshorts%2FabcDEF12345&image=https%3A%2F%2Fimg.youtube.com%2Fthumb.jpg&type=text%2Fhtml'
+    paragraph = make_iframe_paragraph(embedly)
+    out = parser.parse(paragraph)
+    assert_includes out, 'src="https://www.youtube.com/embed/abcDEF12345"'
+  end
+
+  def test_classic_watch_url_still_works_in_jekyll
+    @isForJekyll = true
+    embedly = 'https://cdn.embedly.com/widgets/media.html?src=foo&url=https%3A%2F%2Fwww.youtube.com%2Fwatch%3Fv%3DdQw4w9WgXcQ&image=https%3A%2F%2Fimg.youtube.com%2Fthumb.jpg&type=text%2Fhtml'
+    paragraph = make_iframe_paragraph(embedly)
+    out = parser.parse(paragraph)
+    assert_includes out, 'src="https://www.youtube.com/embed/dQw4w9WgXcQ"'
+  end
+
+  def test_jekyll_falls_back_to_plain_link_when_video_id_unrecoverable
+    @isForJekyll = true
+    embedly = 'https://cdn.embedly.com/widgets/media.html?src=foo&url=https%3A%2F%2Fyoutu.be%2F&image=x&type=text%2Fhtml'
+    paragraph = make_iframe_paragraph(embedly, title: 'broken')
+    out = parser.parse(paragraph)
+    refute_includes out, '<iframe'
+    assert_match(/\[broken\]\(https:\/\/youtu\.be\/\)/, out)
+  end
+
+  def test_plain_mode_downloads_thumbnail_for_youtu_be_url
+    @isForJekyll = false
+    embedly = 'https://cdn.embedly.com/widgets/media.html?src=foo&url=https%3A%2F%2Fyoutu.be%2FdQw4w9WgXcQ&image=https%3A%2F%2Fimg.youtube.com%2Fthumb.jpg&type=text%2Fhtml'
+    paragraph = make_iframe_paragraph(embedly, title: 'rickroll')
+    ImageDownloader.stub(:download, true) do
+      out = parser.parse(paragraph)
+      assert_includes out, '![rickroll]'
+      assert_includes out, '(https://youtu.be/dQw4w9WgXcQ)'
+    end
+  end
+end
+
+class IframeVimeoEmbedTest < Minitest::Test
+  include IframeParserTestSupport
+
+  def test_jekyll_emits_player_iframe_with_video_id
+    @isForJekyll = true
+    embedly = 'https://cdn.embedly.com/widgets/media.html?src=foo&url=https%3A%2F%2Fvimeo.com%2F123456789&image=https%3A%2F%2Fi.vimeocdn.com%2Fthumb.jpg&type=text%2Fhtml'
+    paragraph = make_iframe_paragraph(embedly, title: 'My Vimeo video')
+    out = parser.parse(paragraph)
+    assert_includes out, 'src="https://player.vimeo.com/video/123456789"'
+    assert_includes out, 'My Vimeo video'
+    assert_includes out, 'allowfullscreen'
+  end
+
+  def test_plain_mode_downloads_thumbnail_from_embedly_image_param
+    @isForJekyll = false
+    embedly = 'https://cdn.embedly.com/widgets/media.html?src=foo&url=https%3A%2F%2Fvimeo.com%2F123456789&image=https%3A%2F%2Fi.vimeocdn.com%2Fthumb.jpg&type=text%2Fhtml'
+    paragraph = make_iframe_paragraph(embedly, title: 'My Vimeo video')
+    ImageDownloader.stub(:download, true) do
+      out = parser.parse(paragraph)
+      assert_includes out, '![My Vimeo video]'
+      assert_includes out, '(https://vimeo.com/123456789)'
+    end
+  end
+
+  def test_plain_mode_falls_back_to_og_image_when_no_embedly_image
+    @isForJekyll = false
+    paragraph = make_iframe_paragraph('https://vimeo.com/123456789', title: 'V')
+    Helper.stub(:fetchOGImage, 'https://i.vimeocdn.com/og.jpg') do
+      ImageDownloader.stub(:download, true) do
+        out = parser.parse(paragraph)
+        assert_includes out, '![V]'
+        assert_includes out, '(https://vimeo.com/123456789)'
+      end
+    end
+  end
+
+  def test_plain_mode_falls_back_to_plain_link_when_no_image_anywhere
+    @isForJekyll = false
+    paragraph = make_iframe_paragraph('https://vimeo.com/123456789', title: 'V')
+    Helper.stub(:fetchOGImage, '') do
+      out = parser.parse(paragraph)
+      assert_match(/\[V\]\(https:\/\/vimeo\.com\/123456789\)/, out)
+      refute_includes out, '![V]'
+    end
+  end
+end
+
+class IframeSoundCloudEmbedTest < Minitest::Test
+  include IframeParserTestSupport
+
+  def test_jekyll_emits_soundcloud_player_iframe
+    @isForJekyll = true
+    paragraph = make_iframe_paragraph('https://soundcloud.com/artist/track-name', title: 'a track')
+    out = parser.parse(paragraph)
+    assert_includes out, 'w.soundcloud.com/player'
+    assert_includes out, 'url=https%3A%2F%2Fsoundcloud.com%2Fartist%2Ftrack-name'
+    assert_includes out, 'a track'
+  end
+
+  def test_plain_mode_falls_through_to_og_image
+    @isForJekyll = false
+    paragraph = make_iframe_paragraph('https://soundcloud.com/artist/track-name', title: 'a track')
+    Helper.stub(:fetchOGImage, 'https://i1.sndcdn.com/og.jpg') do
+      ImageDownloader.stub(:download, true) do
+        Request.stub(:URL, nil) do
+          # Plain mode goes through parseOgImageEmbed, which doesn't need the
+          # html-fetch step (we route off the inner URL before that).
+          # We need the html-fetch path though, so stub it to return non-nil.
+          fake_html = Nokogiri::HTML('<html><body></body></html>')
+          Request.stub(:html, fake_html) do
+            out = parser.parse(paragraph)
+            assert_includes out, '![a track]'
+            assert_includes out, '(https://soundcloud.com/artist/track-name)'
+          end
+        end
+      end
+    end
+  end
+end
+
+class IframeSpotifyEmbedTest < Minitest::Test
+  include IframeParserTestSupport
+
+  def test_jekyll_emits_track_embed_iframe
+    @isForJekyll = true
+    paragraph = make_iframe_paragraph('https://open.spotify.com/track/3n3Ppam7vgaVa1iaRUc9Lp', title: 'a song')
+    out = parser.parse(paragraph)
+    assert_includes out, 'src="https://open.spotify.com/embed/track/3n3Ppam7vgaVa1iaRUc9Lp"'
+    assert_includes out, 'a song'
+  end
+
+  def test_jekyll_emits_album_embed_iframe
+    @isForJekyll = true
+    paragraph = make_iframe_paragraph('https://open.spotify.com/album/1A2GTWGtFfWp7KSQTwWOyo')
+    out = parser.parse(paragraph)
+    assert_includes out, 'src="https://open.spotify.com/embed/album/1A2GTWGtFfWp7KSQTwWOyo"'
+  end
+
+  def test_jekyll_emits_episode_embed_iframe
+    @isForJekyll = true
+    paragraph = make_iframe_paragraph('https://open.spotify.com/episode/4xUZb4l9qjUE0HwGGVwAYj')
+    out = parser.parse(paragraph)
+    assert_includes out, 'src="https://open.spotify.com/embed/episode/4xUZb4l9qjUE0HwGGVwAYj"'
+  end
+end
+
+class IframeRegistryDispatchTest < Minitest::Test
+  include IframeParserTestSupport
+
+  def test_widgetic_still_short_circuits_without_network
+    paragraph = make_iframe_paragraph('https://app.widgetic.com/composition/abc')
+    # No Request stub -> any network call would NoMethodError.
+    assert_nil parser.parse(paragraph)
+  end
+
+  def test_unknown_host_falls_through_to_og_image_path
+    @isForJekyll = false
+    paragraph = make_iframe_paragraph('https://example.com/some-cool-thing', title: 'cool')
+    fake_html = Nokogiri::HTML('<html><body></body></html>')
+    Request.stub(:URL, nil) do
+      Request.stub(:html, fake_html) do
+        Helper.stub(:fetchOGImage, 'https://example.com/og.jpg') do
+          out = parser.parse(paragraph)
+          assert_includes out, '![cool]'
+          assert_includes out, '(https://example.com/some-cool-thing)'
+        end
+      end
+    end
+  end
+end

--- a/test/paywall_message_test.rb
+++ b/test/paywall_message_test.rb
@@ -1,0 +1,41 @@
+require_relative 'test_helper'
+
+class PaywallMessageTest < Minitest::Test
+  def setup
+    @prev_cookies = $cookies
+    @fetcher = ZMediumFetcher.new
+  end
+
+  def teardown
+    $cookies = @prev_cookies
+  end
+
+  def test_prompts_to_provide_cookies_when_none_present
+    $cookies = {}
+    msg = @fetcher.paywallMessage
+    assert_match(/Provide your Medium Member cookies/, msg)
+    assert_match(/-s SID -d UID/, msg)
+  end
+
+  def test_prompts_to_provide_cookies_when_jar_has_blank_values
+    $cookies = { 'sid' => '', 'uid' => '' }
+    msg = @fetcher.paywallMessage
+    assert_match(/Provide your Medium Member cookies/, msg)
+  end
+
+  def test_suggests_cookie_validity_when_cookies_were_already_set
+    $cookies = { 'sid' => 'real_sid', 'uid' => 'real_uid' }
+    msg = @fetcher.paywallMessage
+    assert_match(/cookies don't grant access/, msg)
+    assert_match(/Medium Member account/, msg)
+    assert_match(/expire/, msg)
+  end
+
+  def test_treats_partial_cookies_as_provided
+    # If only sid is set, we still consider this an "authenticated" attempt
+    # and surface the cookie-validity message rather than the setup prompt.
+    $cookies = { 'sid' => 'real_sid' }
+    msg = @fetcher.paywallMessage
+    assert_match(/cookies don't grant access/, msg)
+  end
+end

--- a/test/request_cloudflare_test.rb
+++ b/test/request_cloudflare_test.rb
@@ -1,0 +1,63 @@
+require_relative 'test_helper'
+
+class RequestCloudflareDetectionTest < Minitest::Test
+  FakeResponse = Struct.new(:code, :headers, :body) do
+    def [](name)
+      headers[name]
+    end
+  end
+
+  def make(code, header_value: nil, body: '')
+    FakeResponse.new(code.to_s, { 'cf-mitigated' => header_value }, body)
+  end
+
+  def test_403_with_cf_mitigated_challenge_is_detected
+    assert Request.cloudflareBlocked?(make(403, header_value: 'challenge'))
+  end
+
+  def test_403_with_cf_mitigated_block_is_detected
+    assert Request.cloudflareBlocked?(make(403, header_value: 'block'))
+  end
+
+  def test_503_with_managed_challenge_header_is_detected
+    assert Request.cloudflareBlocked?(make(503, header_value: 'managed_challenge'))
+  end
+
+  def test_403_with_just_a_moment_body_is_detected
+    body = '<html><body><h1>Just a moment...</h1><div id="cf-error-details"></div></body></html>'
+    assert Request.cloudflareBlocked?(make(403, body: body))
+  end
+
+  def test_503_with_attention_required_body_is_detected
+    body = '<html><body><h1>Attention Required! | Cloudflare</h1></body></html>'
+    assert Request.cloudflareBlocked?(make(503, body: body))
+  end
+
+  def test_403_with_unrelated_body_is_not_treated_as_cloudflare
+    assert_equal false, Request.cloudflareBlocked?(make(403, body: '<h1>Forbidden by app</h1>'))
+  end
+
+  def test_200_with_just_a_moment_body_is_not_a_block
+    # We deliberately only check Cloudflare on error codes; a 200 page
+    # that happens to contain the phrase shouldn't be treated as blocked.
+    assert_equal false, Request.cloudflareBlocked?(make(200, body: 'Just a moment...'))
+  end
+
+  def test_404_is_not_cloudflare
+    assert_equal false, Request.cloudflareBlocked?(make(404))
+  end
+
+  def test_nil_response_returns_false
+    assert_equal false, Request.cloudflareBlocked?(nil)
+  end
+
+  def test_error_message_carries_cookie_setup_guidance
+    err = Request::CloudflareBlockedError.new(403, 'https://medium.com/_/graphql')
+    msg = err.message
+    assert_match(/HTTP 403/, msg)
+    assert_match(/https:\/\/medium.com\/_\/graphql/, msg)
+    assert_match(/-s YOUR_SID -d YOUR_UID/, msg)
+    assert_match(/MEDIUM_COOKIE_SID/, msg)
+    assert_match(/zhgchg.li/, msg)
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -29,6 +29,7 @@ require 'Parsers/FallbackParser'
 require 'Parsers/MarkupParser'
 require 'Parsers/MarkupStyleRender'
 require 'ZMediumFetcher'
+require 'CLI'
 
 module TestSupport
   POST_ID = 'abcdef123456'.freeze

--- a/test/twitter_embed_test.rb
+++ b/test/twitter_embed_test.rb
@@ -1,0 +1,257 @@
+require_relative 'test_helper'
+
+class TwitterEmbedTokenTest < Minitest::Test
+  def test_generates_non_empty_alphanumeric_token
+    token = TwitterEmbed.generateToken('1234567890123456789')
+    assert_kind_of String, token
+    refute_empty token
+    refute_includes token, '0'
+    refute_includes token, '.'
+    assert_match(/\A[a-z0-9]+\z/, token)
+  end
+
+  def test_token_is_deterministic_for_same_id
+    a = TwitterEmbed.generateToken('1700000000000000000')
+    b = TwitterEmbed.generateToken('1700000000000000000')
+    assert_equal a, b
+  end
+
+  def test_token_differs_for_different_ids
+    a = TwitterEmbed.generateToken('1700000000000000000')
+    b = TwitterEmbed.generateToken('1800000000000000000')
+    refute_equal a, b
+  end
+end
+
+class TwitterEmbedRenderTest < Minitest::Test
+  def base_tweet
+    {
+      'text' => 'hello world',
+      'user' => { 'name' => 'Alice', 'screen_name' => 'alice' },
+      'created_at' => '2024-01-15T10:30:00.000Z',
+      'entities' => { 'user_mentions' => [], 'urls' => [] }
+    }
+  end
+
+  def test_renders_blockquote_with_author_text_and_date
+    md = TwitterEmbed.renderMarkdown(base_tweet, 'https://twitter.com/alice/status/1', jekyllOpen: '')
+    assert_includes md, '[Alice](https://twitter.com/alice)'
+    assert_includes md, '@ Twitter Says:'
+    assert_includes md, '> > hello world'
+    assert_includes md, 'Tweeted at [2024-01-15 10:30:00](https://twitter.com/alice/status/1)'
+    assert_includes md, '■■■■■■■■■■■■■■'
+  end
+
+  def test_falls_back_to_screen_name_when_display_name_missing
+    tweet = base_tweet.merge('user' => { 'screen_name' => 'alice' })
+    md = TwitterEmbed.renderMarkdown(tweet, 'https://twitter.com/alice/status/1', jekyllOpen: '')
+    assert_includes md, '[alice](https://twitter.com/alice)'
+  end
+
+  def test_returns_nil_for_non_hash_input
+    assert_nil TwitterEmbed.renderMarkdown(nil, 'http://x', jekyllOpen: '')
+    assert_nil TwitterEmbed.renderMarkdown('oops', 'http://x', jekyllOpen: '')
+  end
+
+  def test_appends_jekyll_target_blank_marker
+    md = TwitterEmbed.renderMarkdown(base_tweet, 'https://twitter.com/alice/status/1', jekyllOpen: '{:target="_blank"}')
+    # Both author link and date link should carry the marker.
+    assert_equal 2, md.scan('{:target="_blank"}').size
+  end
+
+  def test_handles_invalid_created_at_gracefully
+    tweet = base_tweet.merge('created_at' => 'not-a-date')
+    md = TwitterEmbed.renderMarkdown(tweet, 'http://t/1', jekyllOpen: '')
+    # Falls back to the raw value instead of raising.
+    assert_includes md, 'not-a-date'
+  end
+
+  def test_handles_blank_created_at
+    tweet = base_tweet.merge('created_at' => nil)
+    md = TwitterEmbed.renderMarkdown(tweet, 'http://t/1', jekyllOpen: '')
+    refute_nil md
+  end
+end
+
+class TwitterEmbedEntityExpansionTest < Minitest::Test
+  def test_expands_user_mentions_into_markdown_links
+    tweet = {
+      'text' => 'hi @bob and charlie',
+      'entities' => {
+        'user_mentions' => [
+          { 'screen_name' => 'bob' },
+          { 'screen_name' => 'charlie' }
+        ],
+        'urls' => []
+      }
+    }
+    out = TwitterEmbed.expandEntities(tweet)
+    assert_includes out, '@[bob](https://twitter.com/bob)'
+    assert_includes out, '[charlie](https://twitter.com/charlie)'
+  end
+
+  def test_expands_short_urls_with_display_label
+    tweet = {
+      'text' => 'see https://t.co/abc for more',
+      'entities' => {
+        'user_mentions' => [],
+        'urls' => [
+          { 'url' => 'https://t.co/abc', 'display_url' => 'example.com/page', 'expanded_url' => 'https://example.com/page' }
+        ]
+      }
+    }
+    out = TwitterEmbed.expandEntities(tweet)
+    assert_includes out, '[example.com/page](https://example.com/page)'
+    refute_includes out, 'https://t.co/abc'
+  end
+
+  def test_falls_back_to_expanded_url_when_display_url_missing
+    tweet = {
+      'text' => 'see https://t.co/abc',
+      'entities' => {
+        'user_mentions' => [],
+        'urls' => [
+          { 'url' => 'https://t.co/abc', 'expanded_url' => 'https://example.com' }
+        ]
+      }
+    }
+    out = TwitterEmbed.expandEntities(tweet)
+    assert_includes out, '[https://example.com](https://example.com)'
+  end
+
+  def test_handles_missing_entities_dict
+    tweet = { 'text' => 'plain text' }
+    assert_equal 'plain text', TwitterEmbed.expandEntities(tweet)
+  end
+
+  def test_skips_blank_or_nil_entries
+    tweet = {
+      'text' => 'plain',
+      'entities' => {
+        'user_mentions' => [{ 'screen_name' => nil }, {}],
+        'urls' => [{ 'url' => '' }, { 'url' => nil }]
+      }
+    }
+    assert_equal 'plain', TwitterEmbed.expandEntities(tweet)
+  end
+end
+
+class TwitterEmbedFetchTest < Minitest::Test
+  def test_fetch_returns_nil_when_request_body_is_nil
+    Request.stub(:URL, nil) do
+      Request.stub(:body, nil) do
+        assert_nil TwitterEmbed.fetch('1234567890123456789')
+      end
+    end
+  end
+
+  def test_fetch_returns_nil_when_body_is_empty_string
+    Request.stub(:URL, nil) do
+      Request.stub(:body, '') do
+        assert_nil TwitterEmbed.fetch('1234567890123456789')
+      end
+    end
+  end
+
+  def test_fetch_returns_nil_on_invalid_json
+    Request.stub(:URL, nil) do
+      Request.stub(:body, 'not-json{') do
+        assert_nil TwitterEmbed.fetch('1234567890123456789')
+      end
+    end
+  end
+
+  def test_fetch_parses_valid_json_body
+    json = '{"text":"hi","user":{"name":"A","screen_name":"a"}}'
+    Request.stub(:URL, nil) do
+      Request.stub(:body, json) do
+        out = TwitterEmbed.fetch('1234567890123456789')
+        assert_equal 'hi', out['text']
+        assert_equal 'a', out.dig('user', 'screen_name')
+      end
+    end
+  end
+
+  def test_render_falls_back_to_nil_when_fetch_fails
+    Request.stub(:URL, nil) do
+      Request.stub(:body, nil) do
+        assert_nil TwitterEmbed.render('1234567890123456789', 'http://twitter.com/a/status/1')
+      end
+    end
+  end
+
+  def test_render_returns_markdown_when_fetch_succeeds
+    json = '{"text":"hi","user":{"name":"A","screen_name":"a"},"created_at":"2024-01-15T10:30:00.000Z"}'
+    Request.stub(:URL, nil) do
+      Request.stub(:body, json) do
+        md = TwitterEmbed.render('1234567890123456789', 'https://twitter.com/a/status/1', jekyllOpen: '')
+        assert_includes md, '> > hi'
+        assert_includes md, '@ Twitter Says:'
+      end
+    end
+  end
+end
+
+class IframeParserTwitterDispatchTest < Minitest::Test
+  def make_iframe_paragraph(iframeSrc)
+    TestSupport.paragraph(
+      type: 'IFRAME',
+      iframe: { 'mediaResource' => { 'iframeSrc' => iframeSrc, 'title' => 'tweet', 'id' => 't1' } }
+    )
+  end
+
+  def test_renders_twitter_embed_for_direct_twitter_url
+    paragraph = make_iframe_paragraph('https://twitter.com/alice/status/1234567890123456789')
+    parser = IframeParser.new(false)
+    parser.pathPolicy = PathPolicy.new('/abs', 'rel')
+
+    fake = '{"text":"hello","user":{"name":"Alice","screen_name":"alice"},"created_at":"2024-01-15T10:30:00.000Z"}'
+    Request.stub(:URL, nil) do
+      Request.stub(:body, fake) do
+        out = parser.parse(paragraph)
+        assert_includes out, '> > hello'
+        assert_includes out, '[Alice](https://twitter.com/alice)'
+        assert_includes out, '■■■■■■■■■■■■■■'
+      end
+    end
+  end
+
+  def test_renders_twitter_embed_for_embedly_wrapped_twitter_url
+    embedly = 'https://cdn.embedly.com/widgets/media.html?src=foo&url=https%3A%2F%2Ftwitter.com%2Falice%2Fstatus%2F1234567890123456789&type=text%2Fhtml'
+    paragraph = make_iframe_paragraph(embedly)
+    parser = IframeParser.new(false)
+    parser.pathPolicy = PathPolicy.new('/abs', 'rel')
+
+    fake = '{"text":"unwrapped ok","user":{"name":"A","screen_name":"a"},"created_at":"2024-01-15T10:30:00.000Z"}'
+    Request.stub(:URL, nil) do
+      Request.stub(:body, fake) do
+        out = parser.parse(paragraph)
+        assert_includes out, 'unwrapped ok'
+      end
+    end
+  end
+
+  def test_falls_back_to_plain_link_when_twitter_fetch_fails
+    paragraph = make_iframe_paragraph('https://twitter.com/alice/status/1234567890123456789')
+    parser = IframeParser.new(false)
+    parser.pathPolicy = PathPolicy.new('/abs', 'rel')
+
+    Request.stub(:URL, nil) do
+      Request.stub(:body, nil) do
+        out = parser.parse(paragraph)
+        assert_equal '[tweet](https://twitter.com/alice/status/1234567890123456789)', out
+      end
+    end
+  end
+
+  def test_skips_widgetic_without_hitting_network
+    embedly = 'https://cdn.embedly.com/widgets/media.html?src=foo&url=https%3A%2F%2Fapp.widgetic.com%2Fcomposition%2Fabc&type=text%2Fhtml'
+    paragraph = make_iframe_paragraph(embedly)
+    parser = IframeParser.new(false)
+    parser.pathPolicy = PathPolicy.new('/abs', 'rel')
+
+    # Any network call would raise NoMethodError on nil because we don't stub
+    # Request here. The widgetic short-circuit must run before Request.html.
+    assert_nil parser.parse(paragraph)
+  end
+end


### PR DESCRIPTION
Stacks on top of #23 (which itself stacks on the refactor PR) and restores tweet embedding.

## Why

When the original Twitter embed code (Twitter API v1.1 `statuses/show.json` with a hardcoded bearer token) was removed in the refactor PR, twitter URLs degraded to a plain `[title](url)` link — the v1.1 endpoint and that token have been dead for years and couldn't be saved. This PR restores the original blockquote-style embed by routing through Twitter's *public* syndication endpoint, which is the same source Twitter's own publish widget and `vercel/react-tweet` use.

## What

### `lib/Parsers/TwitterEmbed.rb` (new)

| Method | Responsibility |
|---|---|
| `generateToken(id)` | Ports the JS reference algorithm `((id / 1e15) * PI).toString(36).replace(/(0+|\.)/g, '')`. Includes a hand-rolled `Float#to_s(36)` since Ruby's `Float` lacks a base argument. |
| `fetch(id)` | GETs `https://cdn.syndication.twitter.com/tweet-result?id=...&token=...` and returns parsed JSON, or `nil` on any network / parse failure. |
| `renderMarkdown(tweet, url, jekyllOpen:)` | Emits the same blockquote format the v1.1 code used — `■■■■■■■■■■■■■■` banner, `**[Author](https://twitter.com/handle) @ Twitter Says:**`, indented quote, dated link. |
| `expandEntities(tweet)` | Replaces shortened `t.co/...` URLs with `[display_url](expanded_url)` and `@mentions` with `@[handle](https://twitter.com/handle)`. |

`SYNDICATION_HOST` is overridable via `ENV['TWITTER_SYNDICATION_HOST']` so tests / forks can point at a different host.

### `lib/Parsers/IframeParser.rb` (dispatch reordered)

```ruby
return parseYoutube(...) if url.match?(/(www\.youtube\.com)/)

innerURL = unwrapEmbedly(url)
return parseTwitterEmbed(paragraph, innerURL) if innerURL.match?(TWITTER_URL_REGEX)
return nil if innerURL.match?(WIDGETIC_URL_REGEX)

# only now do we hit the network for gist / og-image
html = Request.html(Request.URL(url))
```

embedly wrappers are unwrapped up front so we can route on the inner URL without a wasted HTTP round-trip — twitter and widgetic now short-circuit before `Request.html` / `Request.URL` fire at all. `parseGenericEmbed` renamed to `parseOgImageEmbed` now that twitter / widgetic each have their own branch.

### Failure mode

Any error in `TwitterEmbed.render` (network down, syndication shape change, JSON parse failure, missing `user` block) returns `nil` and the caller falls back to a plain `[title](url)` link — i.e. the current refactor-branch behaviour. So this PR is strictly additive: if the syndication endpoint disappears tomorrow, output regresses gracefully to a plain link rather than raising.

## Tests (24 new)

- **`TwitterEmbedTokenTest`** — deterministic, alphanumeric, differs per id.
- **`TwitterEmbedRenderTest`** — blockquote shape, `{:target="_blank"}` jekyll marker on both author and date links, screen-name fallback when display name is missing, invalid / missing `created_at` handled gracefully.
- **`TwitterEmbedEntityExpansionTest`** — `t.co/...` → `display_url` + `expanded_url`, `@mentions` expanded, missing `entities` dict, blank / nil entries skipped.
- **`TwitterEmbedFetchTest`** — nil / empty / invalid-JSON bodies all return nil; valid JSON parses correctly; `render` falls back to nil cleanly when `fetch` fails.
- **`IframeParserTwitterDispatchTest`** — direct twitter URL dispatches through `TwitterEmbed.fetch`; embedly-wrapped twitter URL is unwrapped before dispatch; failed fetch falls back to a plain link; widgetic embeds short-circuit without ever hitting the network (the test deliberately doesn't stub `Request.URL` to prove this).

Full suite: **125 tests / 292 assertions / 0 failures**. The `post_7c0974856393` golden file is unchanged — widgetic embeds in that fixture still produce blank lines, just without the wasted HTTP request now.

https://claude.ai/code/session_01Jm2xugkfzxmxoiTsmCFpZr

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jm2xugkfzxmxoiTsmCFpZr)_