### PR TITLE
feat: fill in remaining embedly handlers (x.com, youtu.be, Vimeo, SoundCloud, Spotify)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ ZMediumToMarkdown -p "https://medium.com/<USER>/<POST>" -s "$MEDIUM_COOKIE_SID" 
 ## Features
 
 - Download a single post, or every post by a Medium username
-- Full Medium markup support: headings, blockquotes, lists, inline code, code fences with language, images (downloaded locally), embedded gists (rewritten to fenced code), tweets (rendered as blockquotes via the public syndication endpoint), YouTube cards, generic OG-image embeds
+- Full Medium markup support: headings, blockquotes, lists, inline code, code fences with language, images (downloaded locally), embedded gists (rewritten to fenced code), tweets (rendered as blockquotes via the public syndication endpoint — supports both `twitter.com` and `x.com`), YouTube / Vimeo / SoundCloud / Spotify embeds (Jekyll mode emits player iframes; plain mode renders local-thumbnail cards), generic OG-image embeds for everything else
 - Paywalled posts supported when authenticated cookies are provided
 - Jekyll-friendly mode (front matter, `_posts/` layout, asset paths, `{:target="_blank"}` link markers)
 - Skip-already-downloaded based on `last_modified_at` so it’s safe to run on a cron

--- a/lib/Parsers/IframeParser.rb
+++ b/lib/Parsers/IframeParser.rb
@@ -12,11 +12,21 @@ require 'PathPolicy'
 class IframeParser < Parser
     attr_accessor :nextParser, :pathPolicy, :isForJekyll
 
-    YOUTUBE_HOST = "www.youtube.com".freeze
-    GIST_HOST_REGEX = /^(https\:\/\/gist\.github\.com)/.freeze
-    EMBEDLY_HOST_REGEX = /(cdn\.embedly\.com)/.freeze
-    TWITTER_URL_REGEX = /^(https\:\/\/twitter\.com\/){1}.+(\/){1}(\d+)/.freeze
-    WIDGETIC_URL_REGEX = /^(https\:\/\/app\.widgetic\.com)/.freeze
+    GIST_HOST_REGEX     = /^https:\/\/gist\.github\.com/.freeze
+    EMBEDLY_HOST_REGEX  = /cdn\.embedly\.com/.freeze
+
+    # Twitter rebranded to X — match both, plus the mobile subdomain. Capture
+    # group 1 is the tweet ID (used by parseTwitterEmbed).
+    TWITTER_URL_REGEX   = /^https:\/\/(?:(?:mobile\.)?twitter|x)\.com\/[^\/]+\/status\/(\d+)/.freeze
+
+    # Match every YouTube URL form Medium might hand us:
+    #   www.youtube.com/watch?v=ID    youtu.be/ID    youtube.com/shorts/ID    m.youtube.com/...
+    YOUTUBE_HOST_REGEX  = /(?:www\.|m\.)?youtube\.com|youtu\.be/.freeze
+
+    VIMEO_URL_REGEX     = /^https?:\/\/(?:www\.|player\.)?vimeo\.com\/(?:video\/)?(\d+)/.freeze
+    SOUNDCLOUD_URL_REGEX = /^https?:\/\/(?:www\.)?soundcloud\.com\/[^\/]+\/[^?\/]+/.freeze
+    SPOTIFY_URL_REGEX   = /^https?:\/\/open\.spotify\.com\/(track|album|episode|playlist|show)\/([A-Za-z0-9]+)/.freeze
+    WIDGETIC_URL_REGEX  = /^https:\/\/app\.widgetic\.com/.freeze
 
     def initialize(isForJekyll)
         @isForJekyll = isForJekyll
@@ -32,14 +42,18 @@ class IframeParser < Parser
                   paragraph.iframe.src
               end
 
-        return parseYoutube(paragraph, url) if url.match?(/(www\.youtube\.com)/)
+        return parseYoutube(paragraph, url) if url.match?(YOUTUBE_HOST_REGEX)
 
         # Resolve embedly wrappers up front so we can dispatch on the inner
         # URL without doing an unnecessary HTTP round-trip for hosts we
-        # already know how to handle (twitter, widgetic).
+        # already know how to handle.
         innerURL = unwrapEmbedly(url)
-        return parseTwitterEmbed(paragraph, innerURL) if innerURL.match?(TWITTER_URL_REGEX)
-        return nil if innerURL.match?(WIDGETIC_URL_REGEX)
+
+        return parseTwitterEmbed(paragraph, innerURL)         if innerURL.match?(TWITTER_URL_REGEX)
+        return nil                                            if innerURL.match?(WIDGETIC_URL_REGEX)
+        return parseVimeo(paragraph, url, innerURL)           if innerURL.match?(VIMEO_URL_REGEX)
+        return parseSoundCloud(paragraph, innerURL)           if innerURL.match?(SOUNDCLOUD_URL_REGEX)
+        return parseSpotify(paragraph, innerURL)              if innerURL.match?(SPOTIFY_URL_REGEX)
 
         html = Request.html(Request.URL(url))
         return "" unless html
@@ -66,14 +80,20 @@ class IframeParser < Parser
 
     def unwrapEmbedly(url)
         return url unless url.match?(EMBEDLY_HOST_REGEX)
-        params = URI.decode_www_form(URI(decodeURL(url)).query || "").to_h
+        params = embedlyParams(url)
         params["url"] || url
+    end
+
+    # Decodes a `cdn.embedly.com` URL and returns its query params hash.
+    # Returns {} on any parse failure so callers can branch with `params["url"]`.
+    def embedlyParams(url)
+        URI.decode_www_form(URI(decodeURL(url)).query || "").to_h
     rescue URI::InvalidURIError, ArgumentError
-        url
+        {}
     end
 
     def parseTwitterEmbed(paragraph, ogURL)
-        twitterID = ogURL[TWITTER_URL_REGEX, 3]
+        twitterID = ogURL[TWITTER_URL_REGEX, 1]
         return plainLink(paragraph, ogURL) if twitterID.nil?
 
         TwitterEmbed.render(twitterID, ogURL, jekyllOpen: jekyllOpen) ||
@@ -86,30 +106,108 @@ class IframeParser < Parser
         "[#{title}](#{ogURL})#{jekyllOpen}"
     end
 
+    # YouTube: in Jekyll mode emit a <iframe> player; in plain mode download
+    # the embedly-provided thumbnail and emit `[![title](thumb)](videoURL)`.
     def parseYoutube(paragraph, url)
-        youtubeURL = URI(decodeURL(url)).query
-        params = URI.decode_www_form(youtubeURL || "").to_h
-        return "[#{paragraph.iframe.title}](#{url})#{jekyllOpen}" if params["url"].nil?
+        params = embedlyParams(url)
+        targetURL = params["url"] || url
+        return plainLink(paragraph, targetURL) if params["url"].nil?
 
         if isForJekyll
-            vidParams = URI.decode_www_form(URI.parse(params["url"]).query || "").to_h
-            vid = vidParams["v"]
-            "<iframe class=\"embed-video\" loading=\"lazy\" src=\"https://www.youtube.com/embed/#{vid}\" title=\"#{paragraph.iframe.title}\" frameborder=\"0\" allow=\"accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture\" allowfullscreen ></iframe>"
+            vid = extractYoutubeVideoID(targetURL)
+            return plainLink(paragraph, targetURL) if vid.nil? || vid.empty?
+            iframeMarkup("https://www.youtube.com/embed/#{vid}", paragraph.iframe.title || "Youtube",
+                         allow: "accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture")
         else
-            return "[#{paragraph.iframe.title}](#{url})#{jekyllOpen}" if params["image"].nil?
+            return plainLink(paragraph, targetURL) if params["image"].nil?
+            renderThumbnailLink(paragraph, targetURL, params["image"], defaultTitle: "Youtube")
+        end
+    end
 
-            fileName = "#{paragraph.name}_#{URI(params["image"]).path.split("/").last}"
-            imagePathPolicy = PathPolicy.new(pathPolicy.getAbsolutePath(paragraph.postID), pathPolicy.getRelativePath(paragraph.postID))
-            absolutePath = imagePathPolicy.getAbsolutePath(fileName)
-            title = paragraph.iframe.title
-            title = "Youtube" if title.nil? || title == ""
+    # YouTube IDs live in three places depending on URL form:
+    #   ?v=<id>            (canonical /watch?v=...)
+    #   /<id>              (youtu.be short links)
+    #   /shorts/<id>       (YouTube Shorts)
+    def extractYoutubeVideoID(url)
+        uri = URI.parse(url)
+        return nil unless uri && uri.host
 
-            if ImageDownloader.download(absolutePath, params["image"])
-                relativePath = imagePathPolicy.getRelativePath(fileName)
-                "\r\n\r\n[![#{title}](#{relativePath} \"#{title}\")](#{params["url"]})#{jekyllOpen}\r\n\r\n"
-            else
-                "\r\n[#{title}](#{params["url"]})#{jekyllOpen}\r\n"
-            end
+        if uri.host.include?('youtu.be')
+            uri.path.delete_prefix('/').split('/').first
+        elsif uri.path.start_with?('/shorts/')
+            uri.path.delete_prefix('/shorts/').split('/').first
+        else
+            URI.decode_www_form(uri.query || '').to_h['v']
+        end
+    rescue URI::InvalidURIError
+        nil
+    end
+
+    # Vimeo: same pattern as YouTube. Embedly tends to ship a thumbnail in
+    # the `image` query param; if it's missing we fall back to og:image.
+    def parseVimeo(paragraph, embedlyURL, innerURL)
+        if isForJekyll
+            vid = innerURL[VIMEO_URL_REGEX, 1]
+            return plainLink(paragraph, innerURL) if vid.nil?
+            iframeMarkup("https://player.vimeo.com/video/#{vid}", paragraph.iframe.title || "Vimeo",
+                         allow: "autoplay; fullscreen; picture-in-picture", aspectClass: "embed-video")
+        else
+            params = embedlyParams(embedlyURL)
+            imageURL = params["image"]
+            imageURL = Helper.fetchOGImage(innerURL) if imageURL.nil? || imageURL.empty?
+            return plainLink(paragraph, innerURL) if imageURL.nil? || imageURL.empty?
+            renderThumbnailLink(paragraph, innerURL, imageURL, defaultTitle: "Vimeo")
+        end
+    end
+
+    # SoundCloud: Jekyll mode emits the official iframe player; plain mode
+    # has no audio embed option, so we render the OG image card if available
+    # and fall back to a plain link.
+    def parseSoundCloud(paragraph, innerURL)
+        if isForJekyll
+            playerURL = "https://w.soundcloud.com/player/?url=#{URI.encode_www_form_component(innerURL)}&color=%23ff5500&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true"
+            iframeMarkup(playerURL, paragraph.iframe.title || "SoundCloud",
+                         allow: "autoplay", aspectClass: "embed-audio")
+        else
+            parseOgImageEmbed(paragraph, innerURL)
+        end
+    end
+
+    # Spotify: Jekyll mode emits the official open.spotify.com/embed iframe;
+    # plain mode falls through to OG image / link.
+    def parseSpotify(paragraph, innerURL)
+        if isForJekyll
+            kind = innerURL[SPOTIFY_URL_REGEX, 1]
+            id   = innerURL[SPOTIFY_URL_REGEX, 2]
+            return plainLink(paragraph, innerURL) if kind.nil? || id.nil?
+            iframeMarkup("https://open.spotify.com/embed/#{kind}/#{id}", paragraph.iframe.title || "Spotify",
+                         allow: "encrypted-media", aspectClass: "embed-audio")
+        else
+            parseOgImageEmbed(paragraph, innerURL)
+        end
+    end
+
+    # Generic Jekyll <iframe> markup used by every video / audio embed.
+    def iframeMarkup(src, title, allow:, aspectClass: "embed-video")
+        "<iframe class=\"#{aspectClass}\" loading=\"lazy\" src=\"#{src}\" title=\"#{title}\" frameborder=\"0\" allow=\"#{allow}\" allowfullscreen ></iframe>"
+    end
+
+    # Downloads `imageURL` into the post asset directory and emits the
+    # standard `[![title](relPath)](targetURL)` markdown. Falls back to a
+    # plain link if the download fails.
+    def renderThumbnailLink(paragraph, targetURL, imageURL, defaultTitle:)
+        fileName = "#{paragraph.name}_#{URI(imageURL).path.split("/").last}"
+        imagePolicy = PathPolicy.new(pathPolicy.getAbsolutePath(paragraph.postID), pathPolicy.getRelativePath(paragraph.postID))
+        absolutePath = imagePolicy.getAbsolutePath(fileName)
+
+        title = paragraph.iframe.title
+        title = defaultTitle if title.nil? || title.empty?
+
+        if ImageDownloader.download(absolutePath, imageURL)
+            relativePath = imagePolicy.getRelativePath(fileName)
+            "\r\n\r\n[![#{title}](#{relativePath} \"#{title}\")](#{targetURL})#{jekyllOpen}\r\n\r\n"
+        else
+            "\r\n[#{title}](#{targetURL})#{jekyllOpen}\r\n"
         end
     end
 

--- a/test/iframe_parser_embeds_test.rb
+++ b/test/iframe_parser_embeds_test.rb
@@ -1,0 +1,249 @@
+require_relative 'test_helper'
+
+# Helpers and shared setup for embedly handler tests.
+module IframeParserTestSupport
+  def make_iframe_paragraph(iframe_src, title: 'embed', id: 'eid')
+    TestSupport.paragraph(
+      type: 'IFRAME',
+      iframe: { 'mediaResource' => { 'iframeSrc' => iframe_src, 'title' => title, 'id' => id } }
+    )
+  end
+
+  def parser
+    p = IframeParser.new(@isForJekyll || false)
+    p.pathPolicy = PathPolicy.new('/abs', 'rel')
+    p
+  end
+
+  def stub_no_network
+    Request.stub(:URL, nil) do
+      Request.stub(:html, nil) do
+        Request.stub(:body, nil) do
+          ImageDownloader.stub(:download, true) do
+            Helper.stub(:fetchOGImage, '') do
+              yield
+            end
+          end
+        end
+      end
+    end
+  end
+end
+
+class IframeXTwitterDispatchTest < Minitest::Test
+  include IframeParserTestSupport
+
+  def test_xcom_url_dispatches_through_twitter_embed
+    paragraph = make_iframe_paragraph('https://x.com/alice/status/1700000000000000001')
+    fake = '{"text":"hello x","user":{"name":"Alice","screen_name":"alice"},"created_at":"2024-01-15T10:30:00.000Z"}'
+    Request.stub(:URL, nil) do
+      Request.stub(:body, fake) do
+        out = parser.parse(paragraph)
+        assert_includes out, '> > hello x'
+        assert_includes out, '[Alice](https://twitter.com/alice)'
+      end
+    end
+  end
+
+  def test_mobile_twitter_url_dispatches_through_twitter_embed
+    paragraph = make_iframe_paragraph('https://mobile.twitter.com/alice/status/1700000000000000002')
+    fake = '{"text":"mobile","user":{"name":"Alice","screen_name":"alice"},"created_at":"2024-01-15T10:30:00.000Z"}'
+    Request.stub(:URL, nil) do
+      Request.stub(:body, fake) do
+        out = parser.parse(paragraph)
+        assert_includes out, '> > mobile'
+      end
+    end
+  end
+
+  def test_embedly_wrapped_xcom_url_dispatches_through_twitter_embed
+    embedly = 'https://cdn.embedly.com/widgets/media.html?src=foo&url=https%3A%2F%2Fx.com%2Falice%2Fstatus%2F1700000000000000003&type=text%2Fhtml'
+    paragraph = make_iframe_paragraph(embedly)
+    fake = '{"text":"unwrapped x","user":{"name":"A","screen_name":"a"},"created_at":"2024-01-15T10:30:00.000Z"}'
+    Request.stub(:URL, nil) do
+      Request.stub(:body, fake) do
+        out = parser.parse(paragraph)
+        assert_includes out, 'unwrapped x'
+      end
+    end
+  end
+end
+
+class IframeYoutubeVariantsTest < Minitest::Test
+  include IframeParserTestSupport
+
+  def test_youtu_be_short_url_extracts_video_id_in_jekyll
+    @isForJekyll = true
+    embedly = 'https://cdn.embedly.com/widgets/media.html?src=foo&url=https%3A%2F%2Fyoutu.be%2FdQw4w9WgXcQ&image=https%3A%2F%2Fimg.youtube.com%2Fthumb.jpg&type=text%2Fhtml'
+    paragraph = make_iframe_paragraph(embedly)
+    out = parser.parse(paragraph)
+    assert_includes out, 'src="https://www.youtube.com/embed/dQw4w9WgXcQ"'
+  end
+
+  def test_youtube_shorts_url_extracts_video_id_in_jekyll
+    @isForJekyll = true
+    embedly = 'https://cdn.embedly.com/widgets/media.html?src=foo&url=https%3A%2F%2Fwww.youtube.com%2Fshorts%2FabcDEF12345&image=https%3A%2F%2Fimg.youtube.com%2Fthumb.jpg&type=text%2Fhtml'
+    paragraph = make_iframe_paragraph(embedly)
+    out = parser.parse(paragraph)
+    assert_includes out, 'src="https://www.youtube.com/embed/abcDEF12345"'
+  end
+
+  def test_classic_watch_url_still_works_in_jekyll
+    @isForJekyll = true
+    embedly = 'https://cdn.embedly.com/widgets/media.html?src=foo&url=https%3A%2F%2Fwww.youtube.com%2Fwatch%3Fv%3DdQw4w9WgXcQ&image=https%3A%2F%2Fimg.youtube.com%2Fthumb.jpg&type=text%2Fhtml'
+    paragraph = make_iframe_paragraph(embedly)
+    out = parser.parse(paragraph)
+    assert_includes out, 'src="https://www.youtube.com/embed/dQw4w9WgXcQ"'
+  end
+
+  def test_jekyll_falls_back_to_plain_link_when_video_id_unrecoverable
+    @isForJekyll = true
+    embedly = 'https://cdn.embedly.com/widgets/media.html?src=foo&url=https%3A%2F%2Fyoutu.be%2F&image=x&type=text%2Fhtml'
+    paragraph = make_iframe_paragraph(embedly, title: 'broken')
+    out = parser.parse(paragraph)
+    refute_includes out, '<iframe'
+    assert_match(/\[broken\]\(https:\/\/youtu\.be\/\)/, out)
+  end
+
+  def test_plain_mode_downloads_thumbnail_for_youtu_be_url
+    @isForJekyll = false
+    embedly = 'https://cdn.embedly.com/widgets/media.html?src=foo&url=https%3A%2F%2Fyoutu.be%2FdQw4w9WgXcQ&image=https%3A%2F%2Fimg.youtube.com%2Fthumb.jpg&type=text%2Fhtml'
+    paragraph = make_iframe_paragraph(embedly, title: 'rickroll')
+    ImageDownloader.stub(:download, true) do
+      out = parser.parse(paragraph)
+      assert_includes out, '![rickroll]'
+      assert_includes out, '(https://youtu.be/dQw4w9WgXcQ)'
+    end
+  end
+end
+
+class IframeVimeoEmbedTest < Minitest::Test
+  include IframeParserTestSupport
+
+  def test_jekyll_emits_player_iframe_with_video_id
+    @isForJekyll = true
+    embedly = 'https://cdn.embedly.com/widgets/media.html?src=foo&url=https%3A%2F%2Fvimeo.com%2F123456789&image=https%3A%2F%2Fi.vimeocdn.com%2Fthumb.jpg&type=text%2Fhtml'
+    paragraph = make_iframe_paragraph(embedly, title: 'My Vimeo video')
+    out = parser.parse(paragraph)
+    assert_includes out, 'src="https://player.vimeo.com/video/123456789"'
+    assert_includes out, 'My Vimeo video'
+    assert_includes out, 'allowfullscreen'
+  end
+
+  def test_plain_mode_downloads_thumbnail_from_embedly_image_param
+    @isForJekyll = false
+    embedly = 'https://cdn.embedly.com/widgets/media.html?src=foo&url=https%3A%2F%2Fvimeo.com%2F123456789&image=https%3A%2F%2Fi.vimeocdn.com%2Fthumb.jpg&type=text%2Fhtml'
+    paragraph = make_iframe_paragraph(embedly, title: 'My Vimeo video')
+    ImageDownloader.stub(:download, true) do
+      out = parser.parse(paragraph)
+      assert_includes out, '![My Vimeo video]'
+      assert_includes out, '(https://vimeo.com/123456789)'
+    end
+  end
+
+  def test_plain_mode_falls_back_to_og_image_when_no_embedly_image
+    @isForJekyll = false
+    paragraph = make_iframe_paragraph('https://vimeo.com/123456789', title: 'V')
+    Helper.stub(:fetchOGImage, 'https://i.vimeocdn.com/og.jpg') do
+      ImageDownloader.stub(:download, true) do
+        out = parser.parse(paragraph)
+        assert_includes out, '![V]'
+        assert_includes out, '(https://vimeo.com/123456789)'
+      end
+    end
+  end
+
+  def test_plain_mode_falls_back_to_plain_link_when_no_image_anywhere
+    @isForJekyll = false
+    paragraph = make_iframe_paragraph('https://vimeo.com/123456789', title: 'V')
+    Helper.stub(:fetchOGImage, '') do
+      out = parser.parse(paragraph)
+      assert_match(/\[V\]\(https:\/\/vimeo\.com\/123456789\)/, out)
+      refute_includes out, '![V]'
+    end
+  end
+end
+
+class IframeSoundCloudEmbedTest < Minitest::Test
+  include IframeParserTestSupport
+
+  def test_jekyll_emits_soundcloud_player_iframe
+    @isForJekyll = true
+    paragraph = make_iframe_paragraph('https://soundcloud.com/artist/track-name', title: 'a track')
+    out = parser.parse(paragraph)
+    assert_includes out, 'w.soundcloud.com/player'
+    assert_includes out, 'url=https%3A%2F%2Fsoundcloud.com%2Fartist%2Ftrack-name'
+    assert_includes out, 'a track'
+  end
+
+  def test_plain_mode_falls_through_to_og_image
+    @isForJekyll = false
+    paragraph = make_iframe_paragraph('https://soundcloud.com/artist/track-name', title: 'a track')
+    Helper.stub(:fetchOGImage, 'https://i1.sndcdn.com/og.jpg') do
+      ImageDownloader.stub(:download, true) do
+        Request.stub(:URL, nil) do
+          # Plain mode goes through parseOgImageEmbed, which doesn't need the
+          # html-fetch step (we route off the inner URL before that).
+          # We need the html-fetch path though, so stub it to return non-nil.
+          fake_html = Nokogiri::HTML('<html><body></body></html>')
+          Request.stub(:html, fake_html) do
+            out = parser.parse(paragraph)
+            assert_includes out, '![a track]'
+            assert_includes out, '(https://soundcloud.com/artist/track-name)'
+          end
+        end
+      end
+    end
+  end
+end
+
+class IframeSpotifyEmbedTest < Minitest::Test
+  include IframeParserTestSupport
+
+  def test_jekyll_emits_track_embed_iframe
+    @isForJekyll = true
+    paragraph = make_iframe_paragraph('https://open.spotify.com/track/3n3Ppam7vgaVa1iaRUc9Lp', title: 'a song')
+    out = parser.parse(paragraph)
+    assert_includes out, 'src="https://open.spotify.com/embed/track/3n3Ppam7vgaVa1iaRUc9Lp"'
+    assert_includes out, 'a song'
+  end
+
+  def test_jekyll_emits_album_embed_iframe
+    @isForJekyll = true
+    paragraph = make_iframe_paragraph('https://open.spotify.com/album/1A2GTWGtFfWp7KSQTwWOyo')
+    out = parser.parse(paragraph)
+    assert_includes out, 'src="https://open.spotify.com/embed/album/1A2GTWGtFfWp7KSQTwWOyo"'
+  end
+
+  def test_jekyll_emits_episode_embed_iframe
+    @isForJekyll = true
+    paragraph = make_iframe_paragraph('https://open.spotify.com/episode/4xUZb4l9qjUE0HwGGVwAYj')
+    out = parser.parse(paragraph)
+    assert_includes out, 'src="https://open.spotify.com/embed/episode/4xUZb4l9qjUE0HwGGVwAYj"'
+  end
+end
+
+class IframeRegistryDispatchTest < Minitest::Test
+  include IframeParserTestSupport
+
+  def test_widgetic_still_short_circuits_without_network
+    paragraph = make_iframe_paragraph('https://app.widgetic.com/composition/abc')
+    # No Request stub -> any network call would NoMethodError.
+    assert_nil parser.parse(paragraph)
+  end
+
+  def test_unknown_host_falls_through_to_og_image_path
+    @isForJekyll = false
+    paragraph = make_iframe_paragraph('https://example.com/some-cool-thing', title: 'cool')
+    fake_html = Nokogiri::HTML('<html><body></body></html>')
+    Request.stub(:URL, nil) do
+      Request.stub(:html, fake_html) do
+        Helper.stub(:fetchOGImage, 'https://example.com/og.jpg') do
+          out = parser.parse(paragraph)
+          assert_includes out, '![cool]'
+          assert_includes out, '(https://example.com/some-cool-thing)'
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Stacks on top of #25 → #24 → #23 → refactor PR.

Audited `IframeParser` and found four classes of embedly content that were either silently broken or fell through to a sub-par OG-image fallback:

| Embed | What was wrong |
|---|---|
| `x.com` / `mobile.twitter.com` | Never reached `TwitterEmbed`. Twitter rebranded — every recently-embedded tweet rendered as a plain link. |
| `youtu.be/<id>` / `youtube.com/shorts/<id>` | Matched the YouTube branch, but the ID extractor only looked at `?v=`, so Jekyll mode emitted `<iframe src="https://www.youtube.com/embed/">` (empty `src`). |
| Vimeo | Worked via the OG fallback but no Jekyll player iframe and no local thumbnail download. |
| SoundCloud / Spotify | Same — no Jekyll player iframe; plain mode at best gives an OG image card. |

## Bug fixes

- **`TWITTER_URL_REGEX`** now matches `x.com`, `mobile.twitter.com`, and `twitter.com`. Capture group simplified to just the tweet ID.
- **`YOUTUBE_HOST_REGEX`** expanded to `(www.|m.)youtube.com|youtu.be`.
- **`extractYoutubeVideoID()`** handles all three URL forms:
    - `?v=<id>` — canonical `/watch`
    - `/<id>` — `youtu.be` short links
    - `/shorts/<id>` — YouTube Shorts
  
  `parseYoutube` falls back to a plain link if the ID can't be recovered, instead of emitting a broken iframe.

## New handlers

- **`parseVimeo`** — Jekyll mode emits a `player.vimeo.com/video/<id>` iframe; plain mode prefers the embedly `image` query param and falls back to `og:image`, then downloads into `assets/<post_id>/` exactly like YouTube does.
- **`parseSoundCloud`** — Jekyll mode emits the official `w.soundcloud.com/player` iframe; plain mode falls through to OG-image (markdown can't embed audio meaningfully).
- **`parseSpotify`** — Jekyll mode emits `open.spotify.com/embed/<kind>/<id>` for `track` / `album` / `episode` / `playlist` / `show`; plain mode falls through to OG-image.

## Refactor

While I was in there, I extracted three helpers so the dispatch is cleaner and adding new handlers is trivial:

- **`embedlyParams(url)`** — decodes a `cdn.embedly.com` URL query into a hash. YouTube, Vimeo, and any future "embedly with image+url params" handler share the parsing path.
- **`renderThumbnailLink(paragraph, target, image, default_title:)`** — downloads the thumbnail to `assets/<post_id>/` and emits the standard `[![title](rel)](targetURL)` markdown. Shared by YouTube and Vimeo plain-mode rendering.
- **`iframeMarkup(src, title, allow:, aspectClass:)`** — single source of truth for every Jekyll video / audio iframe.

## Tests (+19, suite is now 178 / 438)

- `IframeXTwitterDispatchTest` — `x.com`, `mobile.twitter.com`, and embedly-wrapped `x.com` URLs all dispatch through `TwitterEmbed`.
- `IframeYoutubeVariantsTest` — `youtu.be` / `shorts` / classic `/watch` all produce the correct embed iframe in Jekyll mode; broken / empty IDs fall back to a plain link instead of a broken iframe; plain mode downloads the thumbnail for `youtu.be` URLs.
- `IframeVimeoEmbedTest` — Jekyll iframe contains `player.vimeo.com/video/<id>`; plain mode prefers the embedly `image` param and falls back to `og:image`; no-image-anywhere falls back to a plain link.
- `IframeSoundCloudEmbedTest` — Jekyll iframe URL-encodes the inner URL through `w.soundcloud.com/player`; plain mode goes through OG-image.
- `IframeSpotifyEmbedTest` — track / album / episode each map to the right `open.spotify.com/embed/<kind>/<id>` URL.
- `IframeRegistryDispatchTest` — widgetic still short-circuits *without* any network call; unknown hosts still fall through to OG-image.

Full suite: **178 tests / 438 assertions / 0 failures**.

README features bullet bumped to mention the new handlers.

https://claude.ai/code/session_01Jm2xugkfzxmxoiTsmCFpZr

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jm2xugkfzxmxoiTsmCFpZr)_