### PR TITLE
fix: HTML-escape `<`/`>` in no-markup paragraphs for Jekyll output

### DIFF
--- a/lib/Parsers/MarkupStyleRender.rb
+++ b/lib/Parsers/MarkupStyleRender.rb
@@ -57,7 +57,19 @@ class MarkupStyleRender
 
     def parse
         if paragraph.markups.nil? || paragraph.markups.empty?
-            response = chars.values
+            # No markup tags ⇒ walkCharsWithTags is skipped. For Jekyll
+            # output we still need to HTML-escape `<` / `>` so kramdown
+            # doesn't treat raw chars in the source text as bare HTML tags.
+            # Non-Jekyll output keeps the chars as-is.
+            response = if isForJekyll
+                chars.values.map do |c|
+                    next c if c.chars.empty?
+                    escaped = Helper.escapeHTML(c.chars.join, true)
+                    TextChar.new(escaped.chars, "Text")
+                end
+            else
+                chars.values
+            end
         else
             tags = buildTags(paragraph.markups).sort_by(&:startIndex)
             response = walkCharsWithTags(tags)


### PR DESCRIPTION
## Summary

`c02304a` (decompose MarkupStyleRender refactor) introduced a regression in Jekyll output for any paragraph Medium returns **without markups**.

`parse` now splits into two branches:

```ruby
if paragraph.markups.nil? || paragraph.markups.empty?
  response = chars.values            # ← raw chars, no escape
else
  response = walkCharsWithTags(...)  # → emitChar → Helper.escapeHTML
end
```

The no-markup branch bypasses `emitChar` entirely, so `<` / `>` stay literal. kramdown then treats them as bare HTML, and html-proofer flags `<a>` etc. as "missing href".

## Fix

Restore the pre-refactor behavior, but only for `isForJekyll=true`:

- **Jekyll**: escape `<` / `>` to `&lt;` / `&gt;`.
- **Non-Jekyll**: leave chars untouched.

## Repro

```ruby
text = "支援設定 Tag Default Style e.g <a> Tag 套用連結樣式"
p = Paragraph.new({"name"=>"x","text"=>text,"type"=>"ULI","markups"=>[]}, "post")

# before
MarkupStyleRender.new(p, true).parse
# => "支援設定 Tag Default Style e.g <a> Tag 套用連結樣式"

# after
# => "支援設定 Tag Default Style e.g &lt;a&gt; Tag 套用連結樣式"
```

## Test plan

- [x] All 277 existing tests pass
- [x] Manual repro on Jekyll output (`<a>` → `&lt;a&gt;`)
- [x] Manual repro on non-Jekyll output (unchanged: `<a>` stays `<a>`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)