### PR TITLE
fix: don't deadlock the CLI when user closes Chrome before pasting cookies

### DIFF
--- a/lib/CLI.rb
+++ b/lib/CLI.rb
@@ -1,5 +1,6 @@
 require 'optparse'
 require 'fileutils'
+require 'timeout'
 
 require 'ZMediumFetcher'
 require 'Helper'
@@ -10,6 +11,13 @@ require 'Request'
 # of bin/ so it can be exercised by unit tests without spawning processes.
 module CLI
     COOKIE_SETUP_URL = 'https://zhgchg.li/posts/zrealm-dev/medium-api-%E7%88%AC%E5%8F%96%E8%B3%87%E6%96%99%E8%88%87%E7%AA%81%E7%A0%B4-cloudflare-%E9%98%B2%E8%AD%B7-%E5%AE%8C%E6%95%B4-graphql-%E6%93%8D%E4%BD%9C%E6%95%99%E5%AD%B8-88f0fb935120/'.freeze
+
+    # How long we'll wait for the user to paste each cookie before giving
+    # up and continuing without them. The timeout matters because users
+    # commonly walk away to Chrome to grab cookies and might never come
+    # back (closed window, switched apps, lost focus) — without a
+    # timeout the CLI would block on $stdin.gets forever.
+    INTERACTIVE_PROMPT_TIMEOUT_SECONDS = 120
 
     COOKIE_WARNING_BANNER = <<~BANNER.strip.freeze
       ──────────────────────────────────────────────────────────────────────
@@ -35,13 +43,14 @@ module CLI
 
     module_function
 
-    def main(argv, output: $stdout, errput: $stderr, cwd: ENV['PWD'] || ::Dir.pwd)
+    def main(argv, output: $stdout, errput: $stderr, input: $stdin, cwd: ENV['PWD'] || ::Dir.pwd)
         argv = argv.dup
         argv << '-h' if argv.empty?
 
         options = parseArgs(argv, errput: errput)
         loadCookiesFromEnv!
         warnIfNoCookies(options, errput: errput)
+        promptForCookiesIfTTY(options, input: input, errput: errput)
         run(options, cwd, output: output)
     end
 
@@ -127,6 +136,53 @@ module CLI
 
     def willHitMedium?(options)
         !options[:postURL].nil? || !options[:username].nil?
+    end
+
+    # Offer an inline paste flow for sid / uid right after the warning
+    # banner, but ONLY when stdin is a real terminal — never when running
+    # under Docker, GitHub Actions, cron, or any other piped invocation.
+    #
+    # Each line read is wrapped in Timeout so the CLI doesn't deadlock
+    # when the user (very commonly) tabs away to Chrome to copy cookies
+    # and then closes the browser / their terminal / loses focus before
+    # coming back. EOF (Ctrl-D), empty input, and timeout all fall
+    # through to the existing "no cookies, fail loudly later" behaviour.
+    def promptForCookiesIfTTY(options, input: $stdin, errput: $stderr, timeout: INTERACTIVE_PROMPT_TIMEOUT_SECONDS, interactive: nil)
+        return if cookiesPresent?
+        return unless willHitMedium?(options)
+
+        effective_interactive = interactive.nil? ? input.respond_to?(:tty?) && input.tty? : interactive
+        return unless effective_interactive
+
+        errput.puts ""
+        errput.puts "You can paste cookies now (or press Enter / Ctrl-D to skip — we'll continue without them):"
+
+        sid = readCookieLine(input, errput: errput, prompt: "  sid: ", timeout: timeout)
+        $cookies['sid'] = sid unless sid.nil?
+
+        uid = readCookieLine(input, errput: errput, prompt: "  uid: ", timeout: timeout)
+        $cookies['uid'] = uid unless uid.nil?
+    end
+
+    # Returns the trimmed line, or nil for empty / EOF / timeout.
+    # Re-raises Interrupt so Ctrl-C aborts the whole program cleanly.
+    def readCookieLine(input, errput:, prompt:, timeout:)
+        errput.print prompt
+        errput.flush if errput.respond_to?(:flush)
+
+        line = Timeout.timeout(timeout) { input.gets }
+        return nil if line.nil? # EOF (Ctrl-D)
+
+        trimmed = line.strip
+        trimmed.empty? ? nil : trimmed
+    rescue Timeout::Error
+        errput.puts ""
+        errput.puts "[timeout after #{timeout}s] Continuing without cookies."
+        nil
+    rescue Interrupt
+        errput.puts ""
+        errput.puts "Aborted."
+        raise
     end
 
     def run(options, cwd, output: $stdout)

--- a/test/cli_interactive_prompt_test.rb
+++ b/test/cli_interactive_prompt_test.rb
@@ -1,0 +1,154 @@
+require_relative 'test_helper'
+require 'stringio'
+
+# Verifies the interactive cookie prompt does NOT deadlock the CLI when
+# the user follows the cookie banner instructions (open Chrome, copy
+# cookies) but then walks away / closes the browser / loses focus before
+# coming back to paste.
+
+# A stdin-shaped IO that blocks on `gets` forever — used to drive the
+# Timeout::Error branch.
+class BlockingInput
+    def gets
+        sleep 60
+    end
+
+    def tty?
+        true
+    end
+end
+
+# A stdin that lets us drive a sequence of `gets` returns plus a tty? flag.
+class FakeInput
+    def initialize(lines, tty: true)
+        @lines = lines.dup
+        @tty = tty
+    end
+
+    def gets
+        @lines.shift
+    end
+
+    def tty?
+        @tty
+    end
+end
+
+class CLIInteractivePromptTest < Minitest::Test
+    def setup
+        $cookies = {}
+        @err = StringIO.new
+    end
+
+    # --- gating: when do we even attempt to prompt? -----------------------
+
+    def test_skips_prompt_when_stdin_is_not_a_tty
+        input = FakeInput.new([], tty: false)
+        CLI.promptForCookiesIfTTY({ postURL: 'https://medium.com/p/abc' },
+                                  input: input, errput: @err, timeout: 0.1)
+        assert_empty $cookies
+        refute_match(/sid:/, @err.string)
+    end
+
+    def test_skips_prompt_when_cookies_already_present
+        $cookies['sid'] = 'existing'
+        input = FakeInput.new([], tty: true)
+        CLI.promptForCookiesIfTTY({ postURL: 'https://medium.com/p/abc' },
+                                  input: input, errput: @err, timeout: 0.1)
+        assert_equal 'existing', $cookies['sid']
+        refute_match(/sid:/, @err.string)
+    end
+
+    def test_skips_prompt_for_non_medium_invocations
+        # `--version` / `--clean` shouldn't even ask about cookies.
+        input = FakeInput.new(["whatever\n", "whatever\n"], tty: true)
+        CLI.promptForCookiesIfTTY({ version: true },
+                                  input: input, errput: @err, timeout: 0.1, interactive: true)
+        assert_empty $cookies
+    end
+
+    # --- happy paths ------------------------------------------------------
+
+    def test_paste_both_sid_and_uid_populates_cookie_jar
+        input = FakeInput.new(["my_sid_value\n", "my_uid_value\n"], tty: true)
+        CLI.promptForCookiesIfTTY({ postURL: 'https://medium.com/p/abc' },
+                                  input: input, errput: @err, timeout: 1)
+        assert_equal 'my_sid_value', $cookies['sid']
+        assert_equal 'my_uid_value', $cookies['uid']
+    end
+
+    def test_strips_surrounding_whitespace_from_pasted_values
+        input = FakeInput.new(["  sid_with_spaces  \n", "\tuid_with_tab\t\n"], tty: true)
+        CLI.promptForCookiesIfTTY({ postURL: 'https://medium.com/p/abc' },
+                                  input: input, errput: @err, timeout: 1)
+        assert_equal 'sid_with_spaces', $cookies['sid']
+        assert_equal 'uid_with_tab', $cookies['uid']
+    end
+
+    def test_paste_only_sid_does_not_set_uid
+        input = FakeInput.new(["just_sid\n", "\n"], tty: true)
+        CLI.promptForCookiesIfTTY({ postURL: 'https://medium.com/p/abc' },
+                                  input: input, errput: @err, timeout: 1)
+        assert_equal 'just_sid', $cookies['sid']
+        assert_nil $cookies['uid']
+    end
+
+    def test_empty_lines_skip_both_cookies
+        input = FakeInput.new(["\n", "\n"], tty: true)
+        CLI.promptForCookiesIfTTY({ postURL: 'https://medium.com/p/abc' },
+                                  input: input, errput: @err, timeout: 1)
+        assert_nil $cookies['sid']
+        assert_nil $cookies['uid']
+    end
+
+    # --- the bug the user reported: Chrome closed before pasting --------
+
+    def test_does_not_hang_when_user_closes_terminal_before_pasting_sid
+        # gets returning nil on the first read simulates EOF, which is what
+        # happens when the controlling terminal is closed.
+        input = FakeInput.new([nil, nil], tty: true)
+        CLI.promptForCookiesIfTTY({ postURL: 'https://medium.com/p/abc' },
+                                  input: input, errput: @err, timeout: 1)
+        assert_nil $cookies['sid']
+        assert_nil $cookies['uid']
+    end
+
+    def test_does_not_hang_when_user_closes_terminal_after_pasting_sid
+        input = FakeInput.new(["good_sid\n", nil], tty: true)
+        CLI.promptForCookiesIfTTY({ postURL: 'https://medium.com/p/abc' },
+                                  input: input, errput: @err, timeout: 1)
+        assert_equal 'good_sid', $cookies['sid']
+        assert_nil $cookies['uid']
+    end
+
+    def test_falls_back_to_no_cookies_when_input_blocks_past_timeout
+        # Simulates: user opens Chrome to copy cookies, gets distracted
+        # (closes the window, switches workspace, walks away). Without a
+        # timeout the CLI would block on `gets` forever.
+        input = BlockingInput.new
+        elapsed = Time.now
+        CLI.promptForCookiesIfTTY({ postURL: 'https://medium.com/p/abc' },
+                                  input: input, errput: @err, timeout: 0.05)
+        assert_operator (Time.now - elapsed), :<, 5,
+                        'Timeout must trigger quickly even when input never arrives'
+        assert_match(/timeout after 0\.05s/, @err.string)
+        assert_nil $cookies['sid']
+        assert_nil $cookies['uid']
+    end
+
+    def test_propagates_ctrl_c_so_the_program_exits_cleanly
+        input = Object.new
+        def input.gets
+            raise Interrupt
+        end
+        def input.tty?
+            true
+        end
+
+        assert_raises(Interrupt) do
+            CLI.promptForCookiesIfTTY({ postURL: 'https://medium.com/p/abc' },
+                                      input: input, errput: @err, timeout: 1)
+        end
+        assert_match(/Aborted/, @err.string)
+    end
+end


### PR DESCRIPTION
Stacks on top of #26 → #25 → #24 → #23 → refactor PR.

## Why

The cookie-warning banner shipped in #25 walks the user through "open Chrome, log in to Medium, copy `sid` / `uid` from DevTools". Most common failure path I'd seen reported: user tabs to Chrome, finishes auth, **gets distracted, closes the browser window or terminal, and never comes back**. With a naive `$stdin.gets` flow that's a permanent deadlock — the CLI sits forever waiting for input that will never arrive.

This PR adds an interactive paste flow with defensive timeout / EOF handling so the CLI cannot hang.

## What

`CLI.promptForCookiesIfTTY`, called from `main()` right after the warning banner. Behaviour:

| Situation | Behaviour |
|---|---|
| `$stdin` is not a TTY (Docker, CI, cron, piped) | Prompt is skipped entirely. Existing non-interactive behaviour preserved. |
| Cookies already in `$cookies` (env / `-s` / `-d`) | Skipped — no point asking for what we have. |
| Invocation isn't going to hit Medium (`--version`, `--clean`, `--help`, `--new`) | Skipped. |
| User pastes a sid + uid | Stripped of whitespace, written to `$cookies`. |
| User presses Enter on a blank line | Treated as "skip this cookie". |
| User hits Ctrl-D / closes the terminal | EOF → returns `nil` → falls through to existing "no cookies, fail loudly later" path. **No deadlock.** |
| User walks away / closes Chrome / loses focus | After 120s the read times out, we log `[timeout after 120s] Continuing without cookies.` and fall through. **No deadlock.** |
| User hits Ctrl-C | Re-raised after logging `Aborted` so the outer rescue in `bin/ZMediumToMarkdown` exits cleanly. |

The timeout is configurable for tests (`timeout:` kwarg).

## Tests (+11, suite is now 189 / 467)

- **Skip gating**: non-TTY input, already-populated `$cookies`, non-Medium invocations.
- **Happy paths**: paste both, paste `sid` only, whitespace stripping.
- **The reported bug**: EOF before / after the first cookie returns immediately (no deadlock); blocking input with a 50 ms test timeout completes in well under 5 s and logs the timeout message — proves the deadlock fix.
- **Ctrl-C**: re-raised after logging `Aborted`.

The blocking-input test uses a custom `BlockingInput` whose `gets` calls `sleep 60`; with a 50 ms `Timeout` the suite still finishes in ~0.2 s overall.

https://claude.ai/code/session_01Jm2xugkfzxmxoiTsmCFpZr

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jm2xugkfzxmxoiTsmCFpZr)_